### PR TITLE
Use longest match during ACSL variable back-substitution

### DIFF
--- a/src/tricera/Main.scala
+++ b/src/tricera/Main.scala
@@ -428,7 +428,7 @@ class Main (args: Array[String]) {
                             acslArgNames : Seq[String],
                             replaceAlphabetic : Boolean = false) = {
               var s = f
-              for ((acslArg, ind)<- acslArgNames zipWithIndex) {
+              for ((acslArg, ind)<- acslArgNames.view.zipWithIndex.reverse) {
                 val replaceArg =
                   if (replaceAlphabetic)
                     lazabs.viewer.HornPrinter.getAlphabeticChar(ind)


### PR DESCRIPTION
If we have more than 10 variables to replace in the ACSL back-substitution, then e.g. _15 will be mistaken for _1. Suppose that our zipped seq is defined as: `{(x, 1),...,(y, _),...,(a, 15)}`. This results in odd terms like `x5 = y` instead of `a = y`. The solution is to reverse the seq and make sure that we replace the longest matches first.

I'll try to create a regression test next week.