### PR TITLE
Add initial support for ACSL structs

### DIFF
--- a/regression-tests/acsl-contracts/Answers
+++ b/regression-tests/acsl-contracts/Answers
@@ -90,3 +90,15 @@ SAFE
 contract27.hcc
 Warning: enabling heap model
 SAFE
+
+struct-field-access-1-true.hcc
+SAFE
+
+struct-field-access-2-false.hcc
+UNSAFE
+
+struct-field-access-3-true.hcc
+SAFE
+
+struct-field-access-4-false.hcc
+UNSAFE

--- a/regression-tests/acsl-contracts/runtests
+++ b/regression-tests/acsl-contracts/runtests
@@ -28,7 +28,11 @@ TESTS="contract1.hcc  \
        contract24.hcc \
        contract25.hcc \
        contract26.hcc \
-       contract27.hcc"
+       contract27.hcc \
+       struct-field-access-1-true.hcc \
+       struct-field-access-2-false.hcc \
+       struct-field-access-3-true.hcc \
+       struct-field-access-4-false.hcc"
 
 for name in $TESTS; do
     echo

--- a/regression-tests/acsl-contracts/struct-field-access-1-true.hcc
+++ b/regression-tests/acsl-contracts/struct-field-access-1-true.hcc
@@ -1,0 +1,21 @@
+struct S {
+    int f1;
+    int f2;
+};
+
+/*@
+  requires s.f1 > s.f2;
+  ensures \result.f2 == 42;
+  ensures \result.f1 == \old(s).f1
+*/
+struct S foo(struct S s) {
+  s.f2 = 42;
+  return s;
+}
+
+
+void main()
+{
+  struct S s = { 2 , 1 };
+  foo(s);
+}

--- a/regression-tests/acsl-contracts/struct-field-access-1-true.hcc
+++ b/regression-tests/acsl-contracts/struct-field-access-1-true.hcc
@@ -6,7 +6,7 @@ struct S {
 /*@
   requires s.f1 > s.f2;
   ensures \result.f2 == 42;
-  ensures \result.f1 == \old(s).f1
+  ensures \result.f1 == \old(s).f1;
 */
 struct S foo(struct S s) {
   s.f2 = 42;

--- a/regression-tests/acsl-contracts/struct-field-access-2-false.hcc
+++ b/regression-tests/acsl-contracts/struct-field-access-2-false.hcc
@@ -1,0 +1,22 @@
+struct S {
+    int f1;
+    int f2;
+};
+
+/*@
+  requires s.f1 > s.f2;
+  ensures \result.f2 == 42;
+  ensures \result.f1 == \old(s).f1
+*/
+struct S foo(struct S s) {
+  s.f2 = 42;
+  s.f1 = 3; // violates the second post-condition
+  return s;
+}
+
+
+void main()
+{
+  struct S s = { 2 , 1 };
+  foo(s);
+}

--- a/regression-tests/acsl-contracts/struct-field-access-2-false.hcc
+++ b/regression-tests/acsl-contracts/struct-field-access-2-false.hcc
@@ -6,7 +6,7 @@ struct S {
 /*@
   requires s.f1 > s.f2;
   ensures \result.f2 == 42;
-  ensures \result.f1 == \old(s).f1
+  ensures \result.f1 == \old(s).f1;
 */
 struct S foo(struct S s) {
   s.f2 = 42;

--- a/regression-tests/acsl-contracts/struct-field-access-3-true.hcc
+++ b/regression-tests/acsl-contracts/struct-field-access-3-true.hcc
@@ -1,0 +1,31 @@
+struct S3{
+    int a;
+};
+struct S2{
+    int a;
+    struct S3 s3;
+};
+struct S1{
+    int a;
+    struct S2 s2;
+};
+
+/*@
+  requires s.a == 1 && s.s2.a == 3 
+    && s.s2.s3.a == 42;
+  ensures \result.s2 == \old(s).s2;
+*/
+struct S1 foo(struct S1 s) {
+  s.a = 0; // does not affect the postcondition
+  return s;
+}
+
+
+void main()
+{
+  struct S1 s1;
+  s1.s2.s3.a = 42;
+  s1.s2.a = 3;
+  s1.a = 1;
+  foo(s1);
+}

--- a/regression-tests/acsl-contracts/struct-field-access-4-false.hcc
+++ b/regression-tests/acsl-contracts/struct-field-access-4-false.hcc
@@ -1,0 +1,32 @@
+struct S3{
+    int a;
+};
+struct S2{
+    int a;
+    struct S3 s3;
+};
+struct S1{
+    int a;
+    struct S2 s2;
+};
+
+/*@
+  requires s.a == 1 && s.s2.a == 3 
+    && s.s2.s3.a == 42;
+  ensures \result.s2 == \old(s).s2;
+*/
+struct S1 foo(struct S1 s) {
+  s.a = 0; // does not affect the postcondition
+  s.s2.a = 42; // violates the postcondition
+  return s;
+}
+
+
+void main()
+{
+  struct S1 s1;
+  s1.s2.s3.a = 42;
+  s1.s2.a = 3;
+  s1.a = 1;
+  foo(s1);
+}

--- a/src/tricera/postprocessor/ADTExploder.scala
+++ b/src/tricera/postprocessor/ADTExploder.scala
@@ -42,8 +42,7 @@ object ADTExploder extends SolutionProcessor {
   object adtTermExploder extends CollectingVisitor[Object, IExpression] {
     def getADTTerm(t : IExpression) : Option[ADTTerm] = {
       t match {
-        case f @ IFunApp(fun, _) if fun.isInstanceOf[MonoSortedIFunction] &&
-          fun.asInstanceOf[MonoSortedIFunction].resSort.isInstanceOf[ADTProxySort] =>
+        case f @ IFunApp(fun, _) if ADT.Constructor.unapply(fun).nonEmpty =>
           val sortedFun = fun.asInstanceOf[MonoSortedIFunction]
           val adtSort = sortedFun.resSort.asInstanceOf[ADT.ADTProxySort]
           Some(ADTTerm(f, adtSort))


### PR DESCRIPTION
Adds support for ACSL structs. The support currently does not extend to accesses through pointers.

Also makes the thrown ACSL exceptions richer to contain source information (which is not currently utilized).