### PR TITLE
Replace FileInputStream with FileReader in TriCeraParameters

### DIFF
--- a/src/tricera/params/TriCeraParameters.scala
+++ b/src/tricera/params/TriCeraParameters.scala
@@ -29,7 +29,7 @@
 
 package tricera.params
 
-import java.io.FileInputStream
+import java.io.FileReader
 
 import lazabs.GlobalParameters
 import lazabs.horn.abstractions.StaticAbstractionBuilder.AbstractionType
@@ -377,7 +377,7 @@ class TriCeraParameters extends GlobalParameters {
       showHelp
       throw new MainException(s"unrecognized option '$arg'")
     case fn :: rest =>
-      fileName = fn; in = new FileInputStream(fileName); parseArgs(rest)
+      fileName = fn; in = new FileReader(fileName); parseArgs(rest)
   }
 
   var doNotExecute : Boolean = false


### PR DESCRIPTION
This PR replaces instantiation of a `FileInputStream` with an instantiation of a `FileReader` in the `TriCeraParameters` class. This is to adapt the `TriCeraParameters` class to recent changes in the Eldarica API, please see https://github.com/uuverifiers/eldarica/pull/53 for details. Without the changes TriCera fails to build.
