### PR TITLE
Extend stack pointer support in TriCera

### DIFF
--- a/src/tricera/concurrency/CCReader.scala
+++ b/src/tricera/concurrency/CCReader.scala
@@ -163,6 +163,32 @@ object CCReader {
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+trait ProgramBackTranslator
+object DummyBackTranslator extends ProgramBackTranslator
+
+trait CCASTPreprocessor {
+  def translate(prog : Program) : (Program, ProgramBackTranslator)
+}
+
+// 0) Compile visitors in ccparser, currently only the ones in Absyn are compiled.
+//    Look up Princess SMT-LIB parser, which had the same problem which is now fixed.
+//    -- Do the same for the ACSL parser as well.
+// 1) Do type-inference in first pass (could be separate visitors or the same)
+//    Extend EVar class and create a new AST after the pass.
+//    We could also extend the grammar, e.g.,
+//      EvarWithType. Exp17 ::= "$$" CIdent ":" [Declaration_specifier] "##";
+//      This has the advantage of making all generated visitors know about this.
+//    Challenge:
+//       -- ComposVisitor will revert back to the old AST -- won't know about
+//          the augmented classes.
+//       -- Solution: Extend ComposVisitor so that it knows about the new types.
+// 2) Detect pointer types, rewrite call sites.
+//    -- At each call, i) if it is a stack pointer rewrite using a new function
+//       name and global variables.
+// 3) Create copies of functions for stack & heap pointers.
+// 4) Add back-translators.
+// 5) Stretch goal: output contracts in ACSL AST, and implement preprocessors &
+//    back-translators using this.
 
 class CCReader private (prog              : Program,
                         entryFunction     : String,


### PR DESCRIPTION
This PR aims to address #12.

The idea is to introduce an AST preprocessor package (perhaps to be named `astpreprocessor`), where we can run various translators on input programs that update / collect information on the AST prior to sending the final AST to `CCReader`. These AST preprocessors should also include a back-translator for translating back solutions and counterexamples.

Initially, we can consider a solution at AST-level to be all the contracts of the functions. The task would then be to translate contracts over the preprocessed AST to contracts over the AST prior to preprocessing. For instance if the preprocessor created copies of functions `f_1, f_2, ..., f_n` for some function `f` and the solution is for the copy functions, then the back-translator should merge those contracts into a single contract for `f`.

### Task list

0. ~~Compile visitors in ccparser, currently only the ones in Absyn are compiled.~~ (already done prior to creating this PR )
1. Do type-inference in first pass (could be separate visitors or the same)
2. Detect pointer types, rewrite call sites.
3.  Create copies of functions for stack & heap pointers.
4.  Add back-translators.
5.  Stretch goal: output contracts in ACSL AST, and implement preprocessors & back-translators using this.

A more detailed task list is inserted into `CCReader` as comments in the first commit of this PR.