### PR TITLE
Fix for shadowed global variables.

### DIFF
--- a/regression-tests/horn-hcc/Answers
+++ b/regression-tests/horn-hcc/Answers
@@ -71,6 +71,9 @@ false :- main(g:3, h:4), g:3 != 0. (line:8 col:3) (property: user-assertion)
 
 UNSAFE
 
+shadowing-global.hcc
+SAFE
+
 shadowing.hcc
 SAFE
 

--- a/regression-tests/horn-hcc/runtests
+++ b/regression-tests/horn-hcc/runtests
@@ -7,7 +7,7 @@ TESTS="test1.hcc test2.hcc test3.hcc test4.hcc \
        jumps.hcc jumps2.hcc jumps3.hcc \
        functions.hcc functions2.hcc extended-decl.hcc \
        inits.hcc inits2.hcc inits3.hcc \
-       shadowing.hcc disconnected-assertions.hcc \
+       shadowing-global.hcc shadowing.hcc disconnected-assertions.hcc \
        atomic1.hcc atomic2.hcc atomic3.hcc atomic3b.hcc atomic3c.hcc \
        atomic3d.hcc \
        diamond_true-unreach-call1.c unsigned1.hcc \

--- a/regression-tests/toh-contract-translation/Answers
+++ b/regression-tests/toh-contract-translation/Answers
@@ -87,24 +87,6 @@ SAFE
 multadd-1.c
 Warning: no definition of function "non_det_int_ptr" available
 Warning: no definition of function "non_det_int" available
-Warning: The following clause has different terms with the same name (term: b:12)
-main_12(@h_post, a_post, b_post, result_post, a_init_post, b_init_post) :- main39_3(@h, a:11, b:12, result:13, a_init:14, b_init:15, a:11, b:12, result:13), addTwoNumbers_post(@h, a:11, b:12, result:13, a_init:14, b_init:15, a:11, b:12, result:13, @h_post, a_post, b_post, result_post, a_init_post, b_init_post).
-
-Warning: The following clause has different terms with the same name (term: result:13)
-main_12(@h_post, a_post, b_post, result_post, a_init_post, b_init_post) :- main39_3(@h, a:11, b:12, result:13, a_init:14, b_init:15, a:11, b:12, result:13), addTwoNumbers_post(@h, a:11, b:12, result:13, a_init:14, b_init:15, a:11, b:12, result:13, @h_post, a_post, b_post, result_post, a_init_post, b_init_post).
-
-Warning: The following clause has different terms with the same name (term: a:11)
-main_12(@h_post, a_post, b_post, result_post, a_init_post, b_init_post) :- main39_3(@h, a:11, b:12, result:13, a_init:14, b_init:15, a:11, b:12, result:13), addTwoNumbers_post(@h, a:11, b:12, result:13, a_init:14, b_init:15, a:11, b:12, result:13, @h_post, a_post, b_post, result_post, a_init_post, b_init_post).
-
-Warning: The following clause has different terms with the same name (term: b:12)
-addTwoNumbers_pre(@h, a:11, b:12, result:13, a_init:14, b_init:15, a:11, b:12, result:13) :- main39_3(@h, a:11, b:12, result:13, a_init:14, b_init:15, a:11, b:12, result:13).
-
-Warning: The following clause has different terms with the same name (term: result:13)
-addTwoNumbers_pre(@h, a:11, b:12, result:13, a_init:14, b_init:15, a:11, b:12, result:13) :- main39_3(@h, a:11, b:12, result:13, a_init:14, b_init:15, a:11, b:12, result:13).
-
-Warning: The following clause has different terms with the same name (term: a:11)
-addTwoNumbers_pre(@h, a:11, b:12, result:13, a_init:14, b_init:15, a:11, b:12, result:13) :- main39_3(@h, a:11, b:12, result:13, a_init:14, b_init:15, a:11, b:12, result:13).
-
 
 Inferred ACSL annotations
 ================================================================================

--- a/src/tricera/concurrency/CCReader.scala
+++ b/src/tricera/concurrency/CCReader.scala
@@ -1062,7 +1062,7 @@ class CCReader private (prog              : Program,
       val exitPred = newPred(resVar, Some(getLastSourceInfo(funDef.body)))
 
       output(addRichClause(
-        // SSSOWO : Why are the arguments added twice?
+        // TODO: Why are the arguments added twice?
         entryPred(prePredArgs ++ prePredArgs) :- prePred(prePredArgs),
         Some(funDef.sourceInfo)))// todo: correct source info?
 
@@ -3679,9 +3679,7 @@ private def collectVarDecls(dec                    : Dec,
               evalVars
             } else {
               for ((oldVar, argName) <- evalVars zip argNames) yield {
-                val uniqueArgName =
-                  if (LocalVars.vars.exists(v => v.name == argName)) name + "_" + argName
-                  else argName
+                val uniqueArgName = name + "`" + argName
                 new CCVar(uniqueArgName, oldVar.srcInfo, oldVar.typ,
                           oldVar.storage)
               }


### PR DESCRIPTION
This PR fixes issue #16. It does so by making sure that parameter names are always prefixed with the function name in `Symex.evalHelp()`. Prior to this PR the update was only applied if there already was a local variable with the same name as the argument name. However, if there was a global variable with the same name as the parameter, no prefix was applied. This caused the warning "Warning: The following clause has different terms with the same name".

Please note that the character that separates the prefix from the rest has been changed to "`" (backtick). Since backtick is not a legal C identifier character, this makes sure that there is no risk of generating a name that collides with an existing one.

There might be other possible ways to fix this, e.g. to prefix variable names on [CCReader line 1053](https://github.com/uuverifiers/tricera/blob/8128adc1260163284bb6094acd671f3aa7aca7c2/src/tricera/concurrency/CCReader.scala#L1053), but then one should change it when generating function contexts too, since some of those names are used on [CCReader line 1057](https://github.com/uuverifiers/tricera/blob/8128adc1260163284bb6094acd671f3aa7aca7c2/src/tricera/concurrency/CCReader.scala#L1057).