### PR TITLE
Add capabilities for nondeterministic array initialization.

### DIFF
--- a/regression-tests/horn-hcc-array/Answers
+++ b/regression-tests/horn-hcc-array/Answers
@@ -204,6 +204,57 @@ UNSAFE
 array-of-ptr-1.c
 SAFE
 
+nondet-global-array-explicit-1.c
+
+-------------------------------------------------------------------------------------
+Init:
+ main5_5(newBatchHeap(batchAlloc(emptyHeap, O_Int(9), 5)), AddrRange(nthAddr(1), 5)) 
+-------------------------------------------------------------------------------------
+Final:
+ main5_5(newBatchHeap(batchAlloc(emptyHeap, O_Int(9), 5)), AddrRange(nthAddr(1), 5)) 
+-------------------------------------------------------------------------------------
+Failed assertion:
+false :- main5_5(@h, a:1), getInt(read(@h, nthAddrRange(a:1, 0))) != 0. (line:5 col:5) (property: user-assertion)
+
+UNSAFE
+
+nondet-global-array-explicit-2.c
+SAFE
+
+nondet-global-array-explicit-3.c
+Warning: The following clause has different terms with the same name (term: _)
+main5_5(newBatchHeap(batchAlloc(newBatchHeap(batchAlloc(@h, O_Int(_), 5)), O_Int(_), 5)), newAddrRange(batchAlloc(@h, O_Int(_), 5)), newAddrRange(batchAlloc(newBatchHeap(batchAlloc(@h, O_Int(_), 5)), O_Int(_), 5))).
+
+SAFE
+
+nondet-static-array-explicit-1.c
+
+---------------------------------------------------------------------------------------
+Init:
+  main3_5(newBatchHeap(batchAlloc(emptyHeap, O_Int(9), 5)), AddrRange(nthAddr(1), 5))  
+---------------------------------------------------------------------------------------
+                                           |                                           
+                                           |                                           
+                                           V                                           
+ main3_5_1(newBatchHeap(batchAlloc(emptyHeap, O_Int(9), 5)), AddrRange(nthAddr(1), 5)) 
+---------------------------------------------------------------------------------------
+Final:
+ main3_5_1(newBatchHeap(batchAlloc(emptyHeap, O_Int(9), 5)), AddrRange(nthAddr(1), 5)) 
+---------------------------------------------------------------------------------------
+Failed assertion:
+false :- main3_5_1(@h, a:3), getInt(read(@h, nthAddrRange(a:3, 0))) != 0. (line:6 col:5) (property: user-assertion)
+
+UNSAFE
+
+nondet-static-array-explicit-2.c
+SAFE
+
+nondet-static-array-explicit-3.c
+Warning: The following clause has different terms with the same name (term: _)
+main3_5(newBatchHeap(batchAlloc(newBatchHeap(batchAlloc(@h, O_Int(_), 5)), O_Int(_), 5)), newAddrRange(batchAlloc(@h, O_Int(_), 5)), newAddrRange(batchAlloc(newBatchHeap(batchAlloc(@h, O_Int(_), 5)), O_Int(_), 5))).
+
+SAFE
+
 simple-global-memsafety1.c
 SAFE
 
@@ -251,3 +302,54 @@ false :- main7_36_3(@h, a:1, n:4, p:6, i:7), !is_O_Int(read(@h, nthAddrRange(p:6
 
 UNSAFE
 UNSAFE
+
+nondet-global-array-opt-1.c
+
+-------------------------------------------------------------------------------------
+Init:
+ main7_5(newBatchHeap(batchAlloc(emptyHeap, O_Int(9), 5)), AddrRange(nthAddr(1), 5)) 
+-------------------------------------------------------------------------------------
+Final:
+ main7_5(newBatchHeap(batchAlloc(emptyHeap, O_Int(9), 5)), AddrRange(nthAddr(1), 5)) 
+-------------------------------------------------------------------------------------
+Failed assertion:
+false :- main7_5(@h, a:3), getInt(read(@h, nthAddrRange(a:3, 1))) != 0. (line:7 col:5) (property: user-assertion)
+
+UNSAFE
+
+nondet-global-array-opt-2.c
+SAFE
+
+nondet-global-array-opt-3.c
+Warning: The following clause has different terms with the same name (term: _)
+main7_5(newBatchHeap(batchAlloc(newBatchHeap(batchAlloc(@h, O_Int(_), 5)), O_Int(_), 5)), newAddrRange(batchAlloc(@h, O_Int(_), 5)), newAddrRange(batchAlloc(newBatchHeap(batchAlloc(@h, O_Int(_), 5)), O_Int(_), 5))).
+
+SAFE
+
+nondet-static-array-opt-1.c
+
+---------------------------------------------------------------------------------------
+Init:
+  main3_5(newBatchHeap(batchAlloc(emptyHeap, O_Int(9), 5)), AddrRange(nthAddr(1), 5))  
+---------------------------------------------------------------------------------------
+                                           |                                           
+                                           |                                           
+                                           V                                           
+ main3_5_1(newBatchHeap(batchAlloc(emptyHeap, O_Int(9), 5)), AddrRange(nthAddr(1), 5)) 
+---------------------------------------------------------------------------------------
+Final:
+ main3_5_1(newBatchHeap(batchAlloc(emptyHeap, O_Int(9), 5)), AddrRange(nthAddr(1), 5)) 
+---------------------------------------------------------------------------------------
+Failed assertion:
+false :- main3_5_1(@h, a:3), getInt(read(@h, nthAddrRange(a:3, 1))) != 0. (line:6 col:5) (property: user-assertion)
+
+UNSAFE
+
+nondet-static-array-opt-2.c
+SAFE
+
+nondet-static-array-opt-3.c
+Warning: The following clause has different terms with the same name (term: _)
+main4_5(newBatchHeap(batchAlloc(newBatchHeap(batchAlloc(@h, O_Int(_), 5)), O_Int(_), 5)), newAddrRange(batchAlloc(@h, O_Int(_), 5)), newAddrRange(batchAlloc(newBatchHeap(batchAlloc(@h, O_Int(_), 5)), O_Int(_), 5))).
+
+SAFE

--- a/regression-tests/horn-hcc-array/nondet-global-array-explicit-1.c
+++ b/regression-tests/horn-hcc-array/nondet-global-array-explicit-1.c
@@ -1,0 +1,6 @@
+int a[5] = _;
+
+void main() {
+    // Should be UNSAFE
+    assert(a[0] == 0);
+}

--- a/regression-tests/horn-hcc-array/nondet-global-array-explicit-2.c
+++ b/regression-tests/horn-hcc-array/nondet-global-array-explicit-2.c
@@ -1,0 +1,6 @@
+int a[5] = _;
+
+void main() {
+    // Should be UNSAFE - but is currently SAFE 2025-10-02. Needs extension of theory.
+    assert(a[0] == a[1]);
+}

--- a/regression-tests/horn-hcc-array/nondet-global-array-explicit-3.c
+++ b/regression-tests/horn-hcc-array/nondet-global-array-explicit-3.c
@@ -1,0 +1,9 @@
+int a[5] = _;
+int b[5] = _;
+
+void main() {
+    assume(a[0] == b[0]);
+
+    // Should be UNSAFE - but is currently SAFE 2025-10-02. Needs extension of theory.
+    assert(a[1] == b[1]);
+}

--- a/regression-tests/horn-hcc-array/nondet-global-array-opt-1.c
+++ b/regression-tests/horn-hcc-array/nondet-global-array-opt-1.c
@@ -1,0 +1,8 @@
+
+/* Nondeterministically initialized by command line option -forceNondetInit. */
+int a[5];
+
+void main() {
+    // Should be UNSAFE
+    assert(a[1] == 0);
+}

--- a/regression-tests/horn-hcc-array/nondet-global-array-opt-2.c
+++ b/regression-tests/horn-hcc-array/nondet-global-array-opt-2.c
@@ -1,0 +1,8 @@
+
+/* Nondeterministically initialized by command line option -forceNondetInit. */
+int a[5];
+
+void main() {
+    // Should be UNSAFE - but is currently SAFE 2025-10-02. Needs extension of theory.
+    assert(a[0] == a[1]);
+}

--- a/regression-tests/horn-hcc-array/nondet-global-array-opt-3.c
+++ b/regression-tests/horn-hcc-array/nondet-global-array-opt-3.c
@@ -1,0 +1,11 @@
+
+/* Nondeterministically initialized by command line option -forceNondetInit. */
+int a[5];
+int b[5];
+
+void main() {
+    assume(a[0] == b[0]);
+
+    // Should be UNSAFE - but is currently SAFE 2025-10-02. Needs extension of theory.
+    assert(a[1] == b[1]);
+}

--- a/regression-tests/horn-hcc-array/nondet-static-array-explicit-1.c
+++ b/regression-tests/horn-hcc-array/nondet-static-array-explicit-1.c
@@ -1,0 +1,7 @@
+
+void main() {
+    static int a[5] = _;
+
+    // Should be UNSAFE
+    assert(a[0] == 0);
+}

--- a/regression-tests/horn-hcc-array/nondet-static-array-explicit-2.c
+++ b/regression-tests/horn-hcc-array/nondet-static-array-explicit-2.c
@@ -1,0 +1,7 @@
+
+void main() {
+    static int a[5] = _;
+
+    // Should be UNSAFE - but is currently SAFE 2025-10-02. Needs extension of theory.
+    assert(a[0] == a[1]);
+}

--- a/regression-tests/horn-hcc-array/nondet-static-array-explicit-3.c
+++ b/regression-tests/horn-hcc-array/nondet-static-array-explicit-3.c
@@ -1,0 +1,10 @@
+
+void main() {
+    static int a[5] = _;
+    static int b[5] = _;
+
+    assume(a[0] == b[0]);
+
+    // Should be UNSAFE - but is currently SAFE 2025-10-02. Needs extension of theory.
+    assert(a[1] == b[1]);
+}

--- a/regression-tests/horn-hcc-array/nondet-static-array-opt-1.c
+++ b/regression-tests/horn-hcc-array/nondet-static-array-opt-1.c
@@ -1,0 +1,7 @@
+
+void main() {
+    static int a[5]; // Nondeterministically initialized by command line option -forceNondet.
+
+    // Should be UNSAFE
+    assert(a[1] == 0);
+}

--- a/regression-tests/horn-hcc-array/nondet-static-array-opt-2.c
+++ b/regression-tests/horn-hcc-array/nondet-static-array-opt-2.c
@@ -1,0 +1,7 @@
+
+void main() {
+    static int a[5]; // Nondeterministically initialized by command line option -forceNondet.
+
+    // Should be UNSAFE - but is currently SAFE 2025-10-02. Needs extension of theory.
+    assert(a[0] == a[1]);
+}

--- a/regression-tests/horn-hcc-array/nondet-static-array-opt-3.c
+++ b/regression-tests/horn-hcc-array/nondet-static-array-opt-3.c
@@ -1,0 +1,11 @@
+
+void main() {
+    /* Nondeterministically initialized by command line option -forceNondetInit. */
+    static int a[5];
+    static int b[5];
+
+    assume(a[0] == b[0]);
+
+    // Should be UNSAFE - but is currently SAFE 2025-10-02. Needs extension of theory.
+    assert(a[1] == b[1]);
+}

--- a/regression-tests/horn-hcc-array/runtests
+++ b/regression-tests/horn-hcc-array/runtests
@@ -2,7 +2,13 @@
 
 LAZABS=../../tri
 
-TESTS="out-of-bounds-line1.c out-of-bounds-line2.c out-of-bounds-line3.c out-of-bounds-line4.c dynamic-loop1.c simple-dynamic-array.c simple-global-array.c array-single-alloc.c array-inside-struct-1.c pointer-arith-1-safe.c pointer-arith-1-unsafe.c  pointer-arith-2-safe.c  pointer-arith-2-unsafe.c  global-struct-array-1.c array-of-ptr-1.c"
+TESTS="out-of-bounds-line1.c out-of-bounds-line2.c out-of-bounds-line3.c out-of-bounds-line4.c \
+       dynamic-loop1.c simple-dynamic-array.c simple-global-array.c \
+       array-single-alloc.c array-inside-struct-1.c \
+       pointer-arith-1-safe.c pointer-arith-1-unsafe.c  pointer-arith-2-safe.c  pointer-arith-2-unsafe.c \
+       global-struct-array-1.c array-of-ptr-1.c \
+       nondet-global-array-explicit-1.c nondet-global-array-explicit-2.c nondet-global-array-explicit-3.c \
+       nondet-static-array-explicit-1.c nondet-static-array-explicit-2.c nondet-static-array-explicit-3.c"
 
 for name in $TESTS; do
     echo
@@ -26,4 +32,14 @@ for name in $SPLITPROPERTYTESTS; do
     echo $name
     $LAZABS -cex -abstract:off -splitProperties "$@" $name 2>&1 | grep -v 'at '
     # -memtrack can also be added but not required when .yml files are present
+done
+
+NONDETINITESTS="\
+  nondet-global-array-opt-1.c nondet-global-array-opt-2.c nondet-global-array-opt-3.c \
+  nondet-static-array-opt-1.c nondet-static-array-opt-2.c nondet-static-array-opt-3.c"
+
+for name in $NONDETINITESTS; do
+    echo
+    echo $name
+    $LAZABS -cex -abstract:off -forceNondetInit "$@" $name 2>&1 | grep -v 'at '
 done

--- a/regression-tests/horn-hcc/Answers
+++ b/regression-tests/horn-hcc/Answers
@@ -71,6 +71,33 @@ false :- main(g:3, h:4), g:3 != 0. (line:8 col:3) (property: user-assertion)
 
 UNSAFE
 
+inits4.hcc
+SAFE
+
+inits4-explicit.hcc
+
+---------------
+Init:
+ main3_3(1, 0) 
+---------------
+       |       
+       |       
+       V       
+ main4_3(1, 0) 
+---------------
+       |       
+       |       
+       V       
+  main(1, 0)   
+---------------
+Final:
+  main(1, 0)   
+---------------
+Failed assertion:
+false :- main(g:3, h:4), g:3 != 0. (line:9 col:3) (property: user-assertion)
+
+UNSAFE
+
 shadowing-global.hcc
 SAFE
 
@@ -242,6 +269,39 @@ SAFE
 
 static-shadowing-true.c
 SAFE
+
+inits2-opt.hcc
+
+---------------
+Init:
+ main9_3(0, 1) 
+---------------
+Final:
+ main9_3(0, 1) 
+---------------
+Failed assertion:
+false :- main9_3(g:3, h:4), g:3 != 0 | h:4 != 0. (line:9 col:3) (property: user-assertion)
+
+UNSAFE
+
+inits4-opt.hcc
+
+---------------
+Init:
+ main6_3(1, 0) 
+---------------
+       |       
+       |       
+       V       
+  main(1, 0)   
+---------------
+Final:
+  main(1, 0)   
+---------------
+Failed assertion:
+false :- main(g:3, h:4), g:3 != 0. (line:9 col:3) (property: user-assertion)
+
+UNSAFE
 
 test2b.hcc
 Warning: entry function "main" not found

--- a/regression-tests/horn-hcc/inits2-opt.hcc
+++ b/regression-tests/horn-hcc/inits2-opt.hcc
@@ -1,0 +1,10 @@
+
+
+int g;
+unsigned int h;
+
+void main() {
+
+  // Should be UNSAFE due to command line option -forceNondetInit
+  assert(g == 0 && h == 0);
+}

--- a/regression-tests/horn-hcc/inits4-explicit.hcc
+++ b/regression-tests/horn-hcc/inits4-explicit.hcc
@@ -1,0 +1,10 @@
+
+void main() {
+  static int g = _;
+  static unsigned int h = _;
+
+  assert(h >= 0);
+
+  // Should be UNSAFE
+  assert(g == 0);
+}

--- a/regression-tests/horn-hcc/inits4-opt.hcc
+++ b/regression-tests/horn-hcc/inits4-opt.hcc
@@ -1,0 +1,10 @@
+
+void main() {
+  static int g;
+  static unsigned int h;
+
+  assert(h >= 0);
+
+  // Should be UNSAFE due to command line option -forceNondetInit
+  assert(g == 0);
+}

--- a/regression-tests/horn-hcc/inits4.hcc
+++ b/regression-tests/horn-hcc/inits4.hcc
@@ -1,0 +1,8 @@
+
+void main() {
+  static int g;
+  static unsigned int h;
+
+  assert(h >= 0);
+  assert(g == 0);
+}

--- a/regression-tests/horn-hcc/runtests
+++ b/regression-tests/horn-hcc/runtests
@@ -6,7 +6,7 @@ TESTS="test1.hcc test2.hcc test3.hcc test4.hcc \
        test-para2.hcc lazy-eval1.hcc \
        jumps.hcc jumps2.hcc jumps3.hcc \
        functions.hcc functions2.hcc extended-decl.hcc \
-       inits.hcc inits2.hcc inits3.hcc \
+       inits.hcc inits2.hcc inits3.hcc inits4.hcc inits4-explicit.hcc \
        shadowing-global.hcc shadowing.hcc disconnected-assertions.hcc \
        atomic1.hcc atomic2.hcc atomic3.hcc atomic3b.hcc atomic3c.hcc \
        atomic3d.hcc \
@@ -23,6 +23,15 @@ for name in $TESTS; do
     echo
     echo $name
     $LAZABS -cex -abstract:off "$@" $name 2>&1 | grep -v 'at '
+done
+
+# Tests that depend on -forceNondetInit option
+TESTS="inits2-opt.hcc inits4-opt.hcc"
+
+for name in $TESTS; do
+    echo
+    echo $name
+    $LAZABS -cex -abstract:off -forceNondetInit "$@" $name 2>&1 | grep -v 'at '
 done
 
 # disable cex for tests producing unstable output, likely due to different java versions

--- a/src/tricera/concurrency/CCReader.scala
+++ b/src/tricera/concurrency/CCReader.scala
@@ -1482,11 +1482,18 @@ class CCReader private (prog              : Program,
 
         val (actualLhsVar, initValue, initGuard) =
           varDec.maybeInitializer match {
-            case Some(init : InitExpr) =>
-              if (init.exp_.isInstanceOf[Enondet]) {
-                (lhsVar, CCTerm.fromTerm(lhsVar.term, varDec.typ, srcInfo),
-                  lhsVar rangePred)
-              } else {
+            case Some(init : InitExpr) if init.exp_.isInstanceOf[Enondet] => 
+              lhsVar.typ match {
+                case typ : CCHeapArrayPointer =>
+                  val resultExpr =
+                    values.handleUninitializedArrayDecl(
+                      typ, varDec.initArrayExpr, isGlobal || collectOnlyLocalStatic, true)
+                  (lhsVar, resultExpr, IExpression.i(true))
+                case _ =>
+                  (lhsVar, CCTerm.fromTerm(lhsVar.term, varDec.typ, srcInfo),
+                   lhsVar rangePred)
+              }
+            case Some(init : InitExpr) if !init.exp_.isInstanceOf[Enondet] =>
                 // discard useless type conversions
                 val actualInitExp = init.exp_ match {
                   case typeConv : Etypeconv
@@ -1519,7 +1526,6 @@ class CCReader private (prog              : Program,
                   case _ => (lhsVar, res)
                 }
                 (actualLhsVar, actualRes, IExpression.i(true))
-              }
             case Some(_ : InitListOne) | Some(_: InitListTwo) => {
               val initStack =
                 getInitsStack(varDec.maybeInitializer.get, values)
@@ -1555,9 +1561,9 @@ class CCReader private (prog              : Program,
                 case typ : CCHeapArrayPointer =>
                   val resultExpr =
                     values.handleUninitializedArrayDecl(
-                      typ, varDec.initArrayExpr, isGlobal || collectOnlyLocalStatic)
+                      typ, varDec.initArrayExpr, isGlobal || collectOnlyLocalStatic, TriCeraParameters.parameters.value.forceNondetInit)
                   (lhsVar, resultExpr, IExpression.i(true))
-                case _ if isGlobal || collectOnlyLocalStatic  =>
+                case _ if (isGlobal || collectOnlyLocalStatic) && !TriCeraParameters.parameters.value.forceNondetInit =>
                   (lhsVar, CCTerm.fromTerm(varDec.typ.getZeroInit, varDec.typ, srcInfo),
                     lhsVar rangePred)
                 case _ =>

--- a/src/tricera/concurrency/Symex.scala
+++ b/src/tricera/concurrency/Symex.scala
@@ -772,7 +772,8 @@ class Symex private (context        : SymexContext,
 
   def handleUninitializedArrayDecl(arrayTyp         : CCHeapArrayPointer,
                                    sizeExpr         : Option[Constant_expression],
-                                   isGlobalOrStatic : Boolean): CCTerm = {
+                                   isGlobalOrStatic : Boolean,
+                                   forceNondetInit  : Boolean): CCTerm = {
     val sizeTerm = sizeExpr match {
       case Some(expr) =>
         Some(eval(expr.asInstanceOf[Especial].exp_)
@@ -782,7 +783,7 @@ class Symex private (context        : SymexContext,
     }
 
     val result =
-      heapModel.declUninitializedArray(arrayTyp, sizeTerm, isGlobalOrStatic, values)
+      heapModel.declUninitializedArray(arrayTyp, sizeTerm, isGlobalOrStatic, forceNondetInit, values)
     processHeapResult(result).getOrElse(
       throw new TranslationException(
         "Uninitialized array declaration did not return a pointer.")

--- a/src/tricera/concurrency/heap/HeapModel.scala
+++ b/src/tricera/concurrency/heap/HeapModel.scala
@@ -169,6 +169,7 @@ trait HeapModel {
   def declUninitializedArray(arrayTyp         : CCHeapArrayPointer,
                              size             : Option[ITerm],
                              isGlobalOrStatic : Boolean,
+                             forceNondetInit  : Boolean,
                              s                : Seq[CCTerm]) : HeapOperationResult
 
   /**

--- a/src/tricera/concurrency/heap/HeapTheoryModel.scala
+++ b/src/tricera/concurrency/heap/HeapTheoryModel.scala
@@ -428,9 +428,10 @@ class HeapTheoryModel(context           : SymexContext,
   override def declUninitializedArray(arrayTyp         : CCHeapArrayPointer,
                                       size             : Option[ITerm],
                                       isGlobalOrStatic : Boolean,
+                                      forceNondetInit  : Boolean,
                                       s                : Seq[CCTerm])
   : HeapOperationResult = {
-    val objValue = if (isGlobalOrStatic)
+    val objValue = if (isGlobalOrStatic && !forceNondetInit)
                      arrayTyp.elementType.getZeroInit
                    else arrayTyp.elementType.getNonDet
     val objTerm = CCTerm.fromTerm(objValue, arrayTyp.elementType, None)

--- a/src/tricera/params/TriCeraParameters.scala
+++ b/src/tricera/params/TriCeraParameters.scala
@@ -60,6 +60,13 @@ class TriCeraParameters extends GlobalParameters {
   var showVarLineNumbersInTerms : Boolean = false
 
   /**
+   * If set, static and global variables are initialized to
+   * non-deterministic values. Otherwise, they are
+   * initialized to zero (or the given initializer value).
+   */
+  var forceNondetInit : Boolean = false
+
+  /**
    * Properties that TriCera should check.
    * Note that reach safety will be checked by default when no other properties
    * are specified. If any other property is specified, reach safety is not
@@ -307,6 +314,8 @@ class TriCeraParameters extends GlobalParameters {
     case "-valid-memcleanup" :: rest => checkMemCleanup = true; parseArgs(rest)
     case "-splitProperties"  :: rest => splitProperties = true; parseArgs(rest)
 
+    case "-forceNondetInit"  :: rest => forceNondetInit = true; parseArgs(rest)
+
     case arg :: rest if Set("-v", "--version").contains(arg) =>
       println(version); false
     case arg :: rest if Set("-h", "--help").contains(arg) =>
@@ -336,6 +345,7 @@ class TriCeraParameters extends GlobalParameters {
     |                     predicate with 'p1' or 'p2' in its name
     |-m:func            Use function func as entry point (default: main)
     |-cpp               Execute the C preprocessor (cpp) on the input file first, this will produce filename.i
+    |-forceNondetInit   Initialize static and global variables to non-deterministic values.
 
     |Checked properties:
     |-reachsafety       Enables checking of explicitly specified properties via assert statements.


### PR DESCRIPTION
While this PR may look like a massive change (25 files) most of these files are small newly added test cases. Most of the changes for the new features are in CCReader lines 1485-1495. There is also a small change in `HeapModel` to accomodate for forced nondeterministic initialization.

This PR includes two highly related features:
1. A command line option `-forceNondetInit`
2. Nondeterministic initialization of global and static arrays when using the theory of heaps to model arrays.

The introduced command line option `forceNondetInit` will force the initialization of global and static variables to nondeterministic values. This is useful in conjunction with the `-m:<entrypoint>` when checking e.g. library code and you don't want to assume that all globals or statics are zero-initialized.

The second change makes statements like `static int a[5] = _;` become initialized with nondeterministic values. While this was the case in conjunction `-mathArrays` option, it did not work when using the theory of heaps model.

A few new test cases have also been introduced to check these features. Please not that most of these test cases should end with an `UNSAFE` status. However, due to limitations in the current theory of heaps model, some of these cases pass with a `SAFE` status. The test cases are:

```
horn-hcc-arrays/
  nondet-global-array-explicit-2.c
  nondet-global-array-explicit-3.c
  nondet-static-array-explicit-2.c
  nondet-static-array-explicit-3.c
  nondet-global-array-opt-2.c
  nondet-global-array-opt-3.c
  nondet-static-array-opt-2.c
  nondet-static-array-opt-3.c
```
Once the limitation is lifted, these test cases are expected to change. 

This PR closes issues #19, #43 and its parent issue #35.
