### PR TITLE
Update at expressions so that first argument is a string containing a label

### DIFF
--- a/regression-tests/at-expressions/at-old-01-false.c
+++ b/regression-tests/at-expressions/at-old-01-false.c
@@ -7,7 +7,7 @@ void f(int p) {
   g = 30;
   // p = 20, g = 30
 
-  assert($at(Pre, (int)(p)) == 10);
+  assert($at("Pre", (int)(p)) == 10);
  
   g = 5;
 }

--- a/regression-tests/at-expressions/at-old-01-true.c
+++ b/regression-tests/at-expressions/at-old-01-true.c
@@ -7,8 +7,8 @@ int f(int p) {
   g = 30;
   // p = 20, g = 30
 
-  assert($at(Pre, (int)(p + g)) == 15);
-  assert($at(Old, (int)(p + g)) == 15);
+  assert($at("Pre", (int)(p + g)) == 15);
+  assert($at("Old", (int)(p + g)) == 15);
  
   p = 3;
   g = 5;

--- a/regression-tests/at-expressions/simple-01-false.c
+++ b/regression-tests/at-expressions/simple-01-false.c
@@ -8,7 +8,7 @@ L1: // x = 0;
 L2:; // x = 42; y = 3;
   x = 3;
   
-  assert($at(L1, (int)(x+5)) == 5);
-  assert($at(L2, (int)(x+y)) == 43);
+  assert($at("L1", (int)(x+5)) == 5);
+  assert($at("L2", (int)(x+y)) == 43);
   assert(x == 3);
 }

--- a/regression-tests/at-expressions/simple-01-true.c
+++ b/regression-tests/at-expressions/simple-01-true.c
@@ -1,3 +1,5 @@
+typedef int INTEGER;
+
 int main() {
   int x = 0;
   int y = 3;
@@ -8,7 +10,7 @@ L1: // x = 0;
 L2:; // x = 42; y = 3;
   x = 3;
 
-  assert($at(L1, (int)(x+5)) == 5);
-  assert($at(L2, (int)(x+y)) == 45);
+  assert($at("L1", (INTEGER)(x+5)) == 5);
+  assert($at("L2", (int)(x+y)) == 45);
   assert(x == 3);
 }

--- a/src/main/scala/tricera/concurrency/CCAstAtExpressionTransformer.scala
+++ b/src/main/scala/tricera/concurrency/CCAstAtExpressionTransformer.scala
@@ -125,7 +125,15 @@ object CCAstAtExpressionTransformer {
 
           expressionArg match {
             case typecast: Etypeconv =>
-              val label = labelArg.accept(getName, ())
+              val label = labelArg match {
+                case str : Estring =>
+                  str.string_
+                case _ =>
+                  throw new IllegalArgumentException(
+                    s"${tricera.Util.getLineString(p)}: " +
+                    s"The first argument to $atExpressionName must be a " +
+                    s"string containing a label.")
+              }
               val typeName = typecast.type_name_
               val innerExpr = typecast.exp_
               atCallsBuffer += AtCallInfo(label, typeName, innerExpr, p, currentFunc)


### PR DESCRIPTION
Before:
```
  assert($at(SomeLabel, (int)(x+y)) == 42);
```
After:
```
  assert($at("SomeLabel", (int)(x+y)) == 42);
```

Also see https://github.com/zafer-esen/tri-pp/issues/3