### PR TITLE
Support machine arithmetic types on the heap

### DIFF
--- a/regression-tests/horn-contracts/Answers
+++ b/regression-tests/horn-contracts/Answers
@@ -245,3 +245,19 @@ Inferred ACSL annotations
 ================================================================================
 
 SAFE
+
+stackptr-ilp32.hcc
+Warning: The following clause has different terms with the same name (term: globalf1_0p:12)
+main10_5(@h, globalf1_0p:12, c:9.\as[signed bv[32]]) :- c:9 >= -2147483648 & 2147483647 >= c:9 & globalf1_0p:12 >= -2147483648 & 2147483647 >= globalf1_0p:12 & @h = emptyHeap & globalf1_0p:12 = 0.\as[signed bv[32]].
+
+
+Inferred ACSL annotations
+================================================================================
+/* contract for f1 */
+/*@
+  requires \valid(p) && 2147483647 >= *p && *p >= -2147483648;
+  ensures \valid(p) && (*p == 0 || \old(*p) >= 2147483648 || -2147483649 >= \old(*p));
+*/
+================================================================================
+
+SAFE

--- a/regression-tests/horn-contracts/runtests
+++ b/regression-tests/horn-contracts/runtests
@@ -31,3 +31,10 @@ for name in $TESTS; do
     echo $name
     $LAZABS -cex -acsl -m:entryPoint "$@" $name 2>&1 | grep -v 'at '
 done
+
+ILP32TESTS="stackptr-ilp32.hcc"
+for name in $ILP32TESTS; do
+    echo
+    echo $name
+    $LAZABS -cex -acsl -arithMode:ilp32 "$@" $name 2>&1 | grep -v 'at '
+done

--- a/regression-tests/horn-contracts/stackptr-ilp32.hcc
+++ b/regression-tests/horn-contracts/stackptr-ilp32.hcc
@@ -1,0 +1,12 @@
+/*@contract@*/
+static void f1(int *p)
+{
+    *p = 0;
+}
+
+void main()
+{
+    int c;
+    f1(&c);
+    assert(c == 0);
+}

--- a/regression-tests/horn-hcc-array/Answers
+++ b/regression-tests/horn-hcc-array/Answers
@@ -260,3 +260,6 @@ SAFE
 
 nondet-static-array-opt-3.c
 SAFE
+
+ilp32-bug-1.c
+SAFE

--- a/regression-tests/horn-hcc-array/ilp32-bug-1.c
+++ b/regression-tests/horn-hcc-array/ilp32-bug-1.c
@@ -1,0 +1,9 @@
+int i[2];
+
+void f1() {
+  assert(i[1] == (i[1] & 0x0000FFFF) + (i[1] & 0xFFFF0000));
+}
+
+void main() {
+  f1();
+}

--- a/regression-tests/horn-hcc-array/runtests
+++ b/regression-tests/horn-hcc-array/runtests
@@ -18,6 +18,8 @@ NONDETINITESTS="\
   nondet-global-array-opt-1.c nondet-global-array-opt-2.c nondet-global-array-opt-3.c \
   nondet-static-array-opt-1.c nondet-static-array-opt-2.c nondet-static-array-opt-3.c"
 
+ILP32TESTS="ilp32-bug-1.c"
+
 ## -heapModel:native
 
 for name in $TESTS; do
@@ -44,6 +46,12 @@ for name in $NONDETINITESTS; do
     echo
     echo $name
     $LAZABS -cex -abstract:off -forceNondetInit -heapModel:native "$@" $name 2>&1 | grep -v 'at '
+done
+
+for name in $ILP32TESTS; do
+    echo
+    echo $name
+    $LAZABS -cex -abstract:off -forceNondetInit -heapModel:native -arithMode:ilp32 "$@" $name 2>&1 | grep -v 'at '
 done
 
 ## -heapModel:array

--- a/src/main/scala/tricera/concurrency/CCReader.scala
+++ b/src/main/scala/tricera/concurrency/CCReader.scala
@@ -623,12 +623,21 @@ class CCReader private (prog              : Program,
     }).toList
 
   // todo: only add types that exist in the program - should also add machine arithmetic types
-  val predefSignatures =
-    List(("O_Int", HeapObj.CtorSignature(List(("getInt", HeapObj.OtherSort(Sort.Integer))), ObjSort)),
-         ("O_UInt", HeapObj.CtorSignature(List(("getUInt", HeapObj.OtherSort(Sort.Nat))), ObjSort)),
-         ("O_Addr", HeapObj.CtorSignature(List(("getAddr", HeapObj.AddrSort)), ObjSort)),
-         ("O_AddrRange", HeapObj.CtorSignature(List(("getAddrRange", HeapObj.AddrRangeSort)), ObjSort))
-    )
+  val predefSignatures = List(
+    ("O_Int", HeapObj.CtorSignature(
+      List(("getInt", HeapObj.OtherSort(CCInt.toSort))), ObjSort)),
+    ("O_UInt", HeapObj.CtorSignature(
+      List(("getUInt", HeapObj.OtherSort(CCUInt.toSort))), ObjSort)),
+    ("O_Addr", HeapObj.CtorSignature(
+      List(("getAddr", HeapObj.AddrSort)), ObjSort)),
+    ("O_AddrRange", HeapObj.CtorSignature(
+      List(("getAddrRange", HeapObj.AddrRangeSort)), ObjSort))
+  )
+  // Make sure that we have one object sort per sort
+  private val ctorObjSorts =
+    predefSignatures.flatMap(s => s._2.arguments.map(_._2))
+  assert(ctorObjSorts.toSet.size == ctorObjSorts.size)
+
 
   val wrapperSignatures : List[(String, HeapObj.CtorSignature)] =
     predefSignatures ++
@@ -668,7 +677,8 @@ class CCReader private (prog              : Program,
   val structSels = heap.userHeapSelectors.slice(structCtorsOffset+structCount,
     structCtorsOffset+2*structCount)
 
-  val objectSorts : scala.IndexedSeq[Sort] = objectGetters.toIndexedSeq.map(f => f.resSort)
+  val objectSorts : scala.IndexedSeq[Sort] =
+    objectGetters.toIndexedSeq.map(f => f.resSort)
   val sortGetterMap : Map[Sort, MonoSortedIFunction] =
     objectSorts.zip(objectGetters).toMap
   val sortWrapperMap : Map[Sort, MonoSortedIFunction] =


### PR DESCRIPTION
A fix to support machine arithmetic (using `-arithMode`) in programs with heaps. Fixes #55 and #56.