### PR TITLE
Fix enum-indexed struct ACSL translation

### DIFF
--- a/regression-tests/toh-contract-translation/Answers
+++ b/regression-tests/toh-contract-translation/Answers
@@ -243,3 +243,16 @@ Inferred ACSL annotations
 ================================================================================
 
 SAFE
+
+enum-indexed-struct.c
+
+Inferred ACSL annotations
+================================================================================
+/* contract for helper_read_record */
+/*@
+  requires slot == 1;
+  ensures \old(slot) == 1 && \result.status == \old(records[1].status) && \result.level == \old(records[1].level);
+*/
+================================================================================
+
+SAFE

--- a/regression-tests/toh-contract-translation/enum-indexed-struct.c
+++ b/regression-tests/toh-contract-translation/enum-indexed-struct.c
@@ -1,0 +1,26 @@
+enum RecordSlot {
+    RECORD_LOW = 0,
+    RECORD_HIGH = 1
+};
+
+struct SlotRecord {
+    int level;
+    int status;
+};
+
+struct SlotRecord records[2] = {
+    {3, 0},
+    {8, 1}
+};
+
+/*@contract@*/
+struct SlotRecord helper_read_record(enum RecordSlot slot)
+{
+    return records[slot];
+}
+
+int entry(void)
+{
+    struct SlotRecord selected = helper_read_record(RECORD_HIGH);
+    assert(selected.level == 8);
+}

--- a/regression-tests/toh-contract-translation/runtests
+++ b/regression-tests/toh-contract-translation/runtests
@@ -19,7 +19,7 @@ for name in $TESTS; do
     $TRI_CMD -cex -acsl "$@" $name 2>&1 | grep -v 'at '
 done
 
-TESTS="struct-field-read.c"
+TESTS="struct-field-read.c enum-indexed-struct.c"
 for name in $TESTS; do
     echo
     echo $name

--- a/src/main/scala/tricera/HeapInfo.scala
+++ b/src/main/scala/tricera/HeapInfo.scala
@@ -29,7 +29,10 @@
 package tricera
 
 import ap.theories.heaps.Heap
+import ap.theories.heaps.ArrayHeap
+import ap.theories.heaps.NativeHeap
 import ap.parser.IFunction
+import ap.types.MonoSortedIFunction
 import tricera.concurrency.heap.{HeapModel, HeapTheoryModel}
 
 
@@ -85,6 +88,27 @@ final case class HeapInfo(heap: Heap, heapModel : HeapModel) {
     objectCtorToSel.values.exists(_.contains(func))
 
   def getReadFun: IFunction = heap.read
+
+  def isArrayPointerRangeSelector(function: IFunction): Boolean = heapModel match {
+    case model: HeapTheoryModel => function == model.arrayPtrOps.rangeSel
+    case _ => false
+  }
+
+  def isArrayRangeStart(function: IFunction): Boolean = heap match {
+    case arrayHeap: ArrayHeap => function == arrayHeap.rangeStart
+    case _: NativeHeap => function.name.endsWith("rangeStart")
+    case _ => false
+  }
+
+  def objectFieldSelectors(objectSelector: IFunction): Seq[MonoSortedIFunction] =
+    objectSelector match {
+      case selector: MonoSortedIFunction =>
+        heap.userHeapConstructors.zip(heap.userHeapSelectors).collectFirst {
+          case (constructor, selectors) if constructor.resSort == selector.resSort =>
+            selectors.collect { case field: MonoSortedIFunction => field }
+        }.getOrElse(Seq.empty)
+      case _ => Seq.empty
+    }
 
   def objectCtorToSelector(objectCtor: IFunction): Option[IFunction] =
     objectCtorToSel.get(objectCtor).flatten

--- a/src/main/scala/tricera/postprocessor/ACSLExpressionProcessor.scala
+++ b/src/main/scala/tricera/postprocessor/ACSLExpressionProcessor.scala
@@ -110,6 +110,107 @@ object ACSLExpressionProcessor extends ResultProcessor {
 
     private def isOldHeap(p: ProgVarProxy): Boolean = heapInfo.isHeap(p) && p.isPreExec
 
+    private def isOldRange(range: ITerm): Boolean = range match {
+      case ConstantAsProgVarProxy(p) => p.isPreExec
+      case _ => false
+    }
+
+    private def indexedArrayAccess(address: ITerm): Option[(ITerm, ITerm)] = {
+      def arrayBase(range: ITerm): ITerm = range match {
+        case IFunApp(rangeSelector, Seq(base))
+            if heapInfo.isArrayPointerRangeSelector(rangeSelector) => base
+        case _ => range
+      }
+
+      address match {
+        case IFunApp(rangeNth, Seq(range, index))
+            if rangeNth == heapInfo.heap.rangeNth =>
+          Some((arrayBase(range), index))
+        case IPlus(index, IFunApp(rangeStart, Seq(range)))
+            if heapInfo.isArrayRangeStart(rangeStart) =>
+          range match {
+            case IFunApp(rangeSelector, Seq(base))
+                if heapInfo.isArrayPointerRangeSelector(rangeSelector) =>
+              Some((base, index))
+            case _ => None
+          }
+        case IPlus(IFunApp(rangeStart, Seq(range)), index)
+            if heapInfo.isArrayRangeStart(rangeStart) =>
+          range match {
+            case IFunApp(rangeSelector, Seq(base))
+                if heapInfo.isArrayPointerRangeSelector(rangeSelector) =>
+              Some((base, index))
+            case _ => None
+          }
+        case _ => None
+      }
+    }
+
+    private def arrayElement(
+        heap: ProgVarProxy,
+        range: ITerm,
+        index: ITerm
+    ): ITerm = {
+      val arrayFunction = context match {
+        case _: PreCondition => ACSLExpression.arrayAccess
+        case _: PostCondition =>
+          (isOldHeap(heap), isOldRange(range)) match {
+            case (false, false) => ACSLExpression.arrayAccess
+            case (false, true) => ACSLExpression.arrayAccessOldPointer
+            case (true, _) => ACSLExpression.oldArrayAccess
+          }
+        case _ => ACSLExpression.arrayAccess
+      }
+      ACSLExpression.arrayFunApp(arrayFunction, range, index)
+    }
+
+    private def indexedStructRead(term: ITerm):
+        Option[(IFunction, ProgVarProxy, ITerm)] = term match {
+      case IFunApp(
+            getFun,
+            Seq(
+              TheoryOfHeapFunApp(
+                readFun,
+                Seq(ConstantAsProgVarProxy(h), address: ITerm)
+              )
+            )
+          )
+          if heapInfo.isObjSelector(getFun) &&
+            heapInfo.isReadFun(readFun) &&
+            heapInfo.isHeap(h) &&
+            indexedArrayAccess(address).nonEmpty =>
+        Some((getFun, h, address))
+      case _ => None
+    }
+
+    private def explodeIndexedStructEquality(
+        left: ITerm,
+        right: ITerm
+    ): Option[IFormula] = {
+      val readAndValue = indexedStructRead(left)
+        .map { case (getFun, heap, address) => (getFun, heap, address, right) }
+        .orElse(indexedStructRead(right)
+          .map { case (getFun, heap, address) => (getFun, heap, address, left) })
+
+      readAndValue.flatMap {
+        case (getFun, heap, address, value) =>
+          val fields = heapInfo.objectFieldSelectors(getFun)
+          indexedArrayAccess(address).flatMap { case (array, index) =>
+            val arrayTerm = arrayElement(heap, array, index)
+            if (fields.isEmpty) None
+            else Some(fields.map { field =>
+              val arrayField = context match {
+                case _: PostCondition if isOldHeap(heap) =>
+                  ACSLExpression.oldArrayFieldFunApp(array, index, field)
+                case _ =>
+                  IFunApp(field, Seq(arrayTerm))
+              }
+              arrayField === IFunApp(field, Seq(value))
+            }.reduce(_ &&& _))
+          }
+      }
+    }
+
     override def postVisit(
         t: IExpression,
         dummy: Unit,
@@ -117,6 +218,56 @@ object ACSLExpressionProcessor extends ResultProcessor {
     ): IExpression = {
 
       t match {
+        // A struct-valued array read is represented as a heap-object equality.
+        // Emit field equalities so ACSL consumers do not need struct equality.
+        case IExpression.Eq(left: ITerm, right: ITerm) =>
+          explodeIndexedStructEquality(left, right).getOrElse(t update subres)
+
+        // get_<sort>(read(h, array-address)) ~> a[i]
+        case IFunApp(
+              getFun,
+              Seq(
+                TheoryOfHeapFunApp(
+                  readFun,
+                    Seq(ConstantAsProgVarProxy(h), address: ITerm)
+                )
+              )
+            )
+            if heapInfo.isObjSelector(getFun) &&
+              heapInfo.isReadFun(readFun) &&
+              heapInfo.isHeap(h) &&
+              indexedArrayAccess(address).nonEmpty =>
+          indexedArrayAccess(address) match {
+            case Some((array, index)) => arrayElement(h, array, index)
+            case None => t update subres
+          }
+
+        // field(get_<sort>(read(h, array-address))) ~> a[i].field
+        case IFunApp(
+              selector: MonoSortedIFunction,
+              Seq(
+                IFunApp(
+                  getFun,
+                  Seq(
+                    TheoryOfHeapFunApp(
+                      readFun,
+                      Seq(ConstantAsProgVarProxy(h), address: ITerm)
+                    )
+                  )
+                )
+              )
+            )
+            if heapInfo.isObjSelector(getFun) &&
+              heapInfo.isReadFun(readFun) &&
+              isSelector(selector) &&
+              heapInfo.isHeap(h) &&
+              indexedArrayAccess(address).nonEmpty =>
+          indexedArrayAccess(address) match {
+            case Some((array, index)) =>
+              IFunApp(selector, Seq(arrayElement(h, array, index)))
+            case None => t update subres
+          }
+
         case IFunApp(
               selector: MonoSortedIFunction,
               Seq(

--- a/src/main/scala/tricera/postprocessor/ACSLFunctions.scala
+++ b/src/main/scala/tricera/postprocessor/ACSLFunctions.scala
@@ -51,9 +51,26 @@ object ACSLExpression {
   val arrowOldPointer =
     new IFunction("arrowOldPointer", 2, false, false) // \old(p)->a
   val oldArrow = new IFunction("oldArrow", 2, false, false) // \old(p->a)
+  val arrayAccess = new IFunction("arrayAccess", 2, false, false) // a[i]
+  val arrayAccessOldPointer =
+    new IFunction("arrayAccessOldPointer", 2, false, false) // \old(a)[i]
+  val oldArrayAccess =
+    new IFunction("oldArrayAccess", 2, false, false) // \old(a[i])
+  val oldArrayFieldAccess =
+    new IFunction("oldArrayFieldAccess", 2, false, false) // \old(a[i].f)
   val separated = new Predicate("\\separated", 2) // \separated(p1, p2)
 
-  val functions = Set(deref, oldDeref, derefOldPointer, arrow, arrowOldPointer, oldArrow)
+  val functions = Set(
+    deref,
+    oldDeref,
+    derefOldPointer,
+    arrow,
+    arrowOldPointer,
+    oldArrow,
+    arrayAccess,
+    arrayAccessOldPointer,
+    oldArrayAccess,
+    oldArrayFieldAccess)
   val predicates = Set(valid, separated)
 
   def fun2Identifier(fun : IFunction) = fun.name.split("::").last
@@ -76,6 +93,27 @@ object ACSLExpression {
         IConstant(pointer),
         IConstant(new ConstantTerm(fun2Identifier(selector)))
       )
+    )
+  }
+
+  def arrayFunApp(
+      arrayFunction: IFunction,
+      array: ITerm,
+      index: ITerm
+  ) = {
+    IFunApp(arrayFunction, Seq(array, index))
+  }
+
+  def oldArrayFieldFunApp(
+      array: ITerm,
+      index: ITerm,
+      field: MonoSortedIFunction
+  ) = {
+    IFunApp(
+      oldArrayFieldAccess,
+      Seq(
+        arrayFunApp(arrayAccess, array, index),
+        IConstant(new ConstantTerm(fun2Identifier(field))))
     )
   }
 

--- a/src/main/scala/tricera/postprocessor/ACSLLineariser.scala
+++ b/src/main/scala/tricera/postprocessor/ACSLLineariser.scala
@@ -33,6 +33,7 @@ import ap.terfor.ConstantTerm
 import ap.terfor.preds.Predicate
 import ap.terfor.conjunctions.Quantifier
 import ap.parser._
+import ap.types.MonoSortedIFunction
 import IExpression.Sort
 import Sort.:::
 import tricera.{
@@ -422,6 +423,21 @@ object ACSLLineariser {
         case IFunApp(ACSLExpression.oldArrow, Seq(_: IConstant, _: IConstant)) =>
           print("\\old(")
           allButLast(ctxt setPrecLevel 0, "->", ")", 2)
+
+        case IFunApp(ACSLExpression.arrayAccess, Seq(_, _)) =>
+          allButLast(ctxt setPrecLevel 0, "[", "]", 2)
+
+        case IFunApp(ACSLExpression.arrayAccessOldPointer, Seq(_, _)) =>
+          print("\\old(")
+          SubArgs(List(ctxt setParentOp ")[", ctxt setParentOp "]"))
+
+        case IFunApp(ACSLExpression.oldArrayFieldAccess, Seq(_, _)) =>
+          print("\\old(")
+          allButLast(ctxt setPrecLevel 0, ".", ")", 2)
+
+        case IFunApp(ACSLExpression.oldArrayAccess, Seq(_, _)) =>
+          print("\\old(")
+          allButLast(ctxt setPrecLevel 0, "[", "])", 2)
            
         case IFunApp(fun, _) => {
           if (fun.arity == 1) {


### PR DESCRIPTION
## Summary
- Translate enum-indexed array reads into valid ACSL array expressions.
- Expand struct-valued array reads into field-wise equalities, including \old(...) values.
- Add a regression test for an enum-indexed array of structs.

## Validation
- `sbt test assembly`: 6/6 tests passed and assembly succeeded.
- Focused `enum-indexed-struct.c` regression passed.
- Local Saida -> TriCera -> ISP/Eva completed without the previous enum/struct crash. 
(ISP has its own branch for enum)
- WP proved 29/29 goals

The full historical regression suite contains pre-existing failures on the `annot-funcdecs` baseline; the new focused regression passes.