### PR TITLE
Fix multiple issues in translation of solutions with heaps into ACSL contracts

### DIFF
--- a/regression-tests/horn-contracts/Answers
+++ b/regression-tests/horn-contracts/Answers
@@ -123,7 +123,7 @@ Inferred ACSL annotations
 ================================================================================
 /* contract for f */
 /*@
-  requires \true;
+  requires \valid(x);
   ensures \valid(x) && \old(*x) - *x == -1;
 */
 ================================================================================
@@ -149,7 +149,7 @@ Inferred ACSL annotations
 ================================================================================
 /* contract for f */
 /*@
-  requires \true;
+  requires \valid(x);
   ensures \valid(x) && \old(*x) - *x == -1;
 */
 ================================================================================
@@ -164,7 +164,7 @@ Inferred ACSL annotations
 /* contract for mod */
 /*@
   requires \valid(t2) && \valid(t1) && 2147483647 >= t2->val && t2->val >= -2147483647 && 2147483646 >= t1->val && t1->val >= -2147483648;
-  ensures \valid(t2) && \valid(t1) && (\old(t2->val) >= 2147483648 || -2147483648 >= \old(t2->val) || \old(t1->val) >= 2147483647 || -2147483649 >= \old(t1->val) || (\old(t2->val) - t2->val == 1 && \old(t1->val) - t1->val == -1));
+  ensures \valid(t2) && \valid(t1) && \old(t2->val) - t2->val == 1 && \old(t1->val) - t1->val == -1 && 2147483647 >= \old(t2->val) && \old(t2->val) >= -2147483647 && 2147483646 >= \old(t1->val) && \old(t1->val) >= -2147483648;
 */
 ================================================================================
 
@@ -178,12 +178,12 @@ Inferred ACSL annotations
 /* contract for decr */
 /*@
   requires \valid(q) && 2147483647 >= q->val && q->val >= -2147483647;
-  ensures \valid(q) && (\old(q->val) - q->val == 1 || \old(q->val) >= 2147483648 || -2147483648 >= \old(q->val));
+  ensures \valid(q) && \old(q->val) - q->val == 1 && 2147483647 >= \old(q->val) && \old(q->val) >= -2147483647;
 */
 /* contract for incdec */
 /*@
   requires \valid(p) && 2147483646 >= p->val && p->val >= -2147483648;
-  ensures \valid(p) && (\old(p->val) >= 2147483647 || -2147483649 >= \old(p->val) || (p->val == \old(p->val) && 2147483646 >= \old(p->val) && \old(p->val) >= -2147483648));
+  ensures \valid(p) && p->val == \old(p->val) && 2147483646 >= \old(p->val) && \old(p->val) >= -2147483648;
 */
 ================================================================================
 
@@ -224,7 +224,7 @@ Inferred ACSL annotations
 /* contract for incr */
 /*@
   requires \valid(t) && 2147483646 >= t->val && t->val >= -2147483647;
-  ensures \valid(t) && (\old(t->val) - t->val == -1 || \old(t->val) >= 2147483647 || -2147483648 >= \old(t->val));
+  ensures \valid(t) && \old(t->val) - t->val == -1 && 2147483646 >= \old(t->val) && \old(t->val) >= -2147483647;
 */
 ================================================================================
 
@@ -238,7 +238,7 @@ Inferred ACSL annotations
 /* contract for incr */
 /*@
   requires \valid(t) && 2147483646 >= t->val && t->val >= -2147483648;
-  ensures \valid(t) && (\old(t->val) - t->val == -1 || \old(t->val) >= 2147483647 || -2147483649 >= \old(t->val));
+  ensures \valid(t) && \old(t->val) - t->val == -1 && 2147483646 >= \old(t->val) && \old(t->val) >= -2147483648;
 */
 ================================================================================
 
@@ -254,7 +254,7 @@ Inferred ACSL annotations
 /* contract for f1 */
 /*@
   requires \valid(p) && 2147483647 >= *p && *p >= -2147483648;
-  ensures \valid(p) && (*p == 0 || \old(*p) >= 2147483648 || -2147483649 >= \old(*p));
+  ensures \valid(p) && *p == 0 && \old(*p) >= -2147483648 && 2147483647 >= \old(*p);
 */
 ================================================================================
 

--- a/regression-tests/toh-contract-translation/Answers
+++ b/regression-tests/toh-contract-translation/Answers
@@ -8,7 +8,7 @@ Inferred ACSL annotations
 /* contract for get */
 /*@
   requires n == p && n_init >= 1 && \valid(p);
-  ensures n == \old(p) && \old(n_init) == n_init && \old(r1) == r1 && \old(n) == \old(p) && n_init >= 1 && \result >= 0 && \valid(p) && (n_init == \result || 0 >= \result);
+  ensures n == \old(p) && \old(n_init) == n_init && \old(r1) == r1 && \old(n) == \old(p) && n_init >= 1 && \result >= 0 && \valid(p) && (n_init == \result || \old(*p) != n_init);
 */
 ================================================================================
 
@@ -22,13 +22,13 @@ Inferred ACSL annotations
 ================================================================================
 /* contract for decrement */
 /*@
-  requires \separated(a, val) && \separated(a, b) && \valid(val) && \valid(b) && \valid(a);
-  ensures \old(b) == b && \old(a) == a && \old(b_init) == b_init && \old(a_init) == a_init && \separated(a, val) && \separated(a, b) && \valid(val) && \valid(b) && \valid(a) && \old(*val) - *val == 1;
+  requires val == b && \valid(a) && \valid(b) && \separated(a, b);
+  ensures \old(b) == b && \old(a) == a && \old(b_init) == b_init && \old(a_init) == a_init && \valid(val) && \valid(b) && \valid(a) && \separated(a, val) && \separated(a, b) && \old(*val) - *val == 1;
 */
 /* contract for increment */
 /*@
-  requires a == val && \separated(val, b) && \valid(b) && \valid(val);
-  ensures \old(b) == b && \old(a) == \old(val) && \old(b_init) == b_init && \old(a_init) == a_init && a == \old(val) && \separated(val, b) && \valid(b) && \valid(val) && \old(*val) - *val == -1;
+  requires a == val && \valid(b) && \valid(val) && \separated(val, b) && *b == b_init && *val == a_init;
+  ensures \old(b) == b && \old(a) == \old(val) && \old(b_init) == b_init && \old(a_init) == a_init && a == \old(val) && \valid(b) && \valid(val) && \separated(val, b) && \old(*val) - *val == -1;
 */
 ================================================================================
 
@@ -42,12 +42,12 @@ Inferred ACSL annotations
 ================================================================================
 /* contract for decrement */
 /*@
-  requires \valid(val) && \valid(a);
+  requires val == a && \valid(a);
   ensures \old(a) == a && \old(a_init) == a_init && \valid(val) && \valid(a) && \old(*val) - *val == 1;
 */
 /* contract for increment */
 /*@
-  requires a == val && \valid(val);
+  requires a == val && \valid(val) && *val == a_init;
   ensures \old(a) == \old(val) && \old(a_init) == a_init && a == \old(val) && \valid(val) && \old(*val) - *val == -1;
 */
 ================================================================================
@@ -62,8 +62,8 @@ Inferred ACSL annotations
 ================================================================================
 /* contract for findMax */
 /*@
-  requires b == y && a == x && \separated(x, y) && \valid(y) && \valid(x);
-  ensures b == \old(y) && a == \old(x) && \old(b_init) == b_init && \old(a_init) == a_init && \old(r) == r && \old(b) == \old(y) && \old(a) == \old(x) && \separated(x, y) && \valid(y) && \valid(x) && ((\result == b_init && b_init - a_init >= 1) || (\result == a_init && a_init >= b_init));
+  requires b == y && a == x && \valid(y) && \valid(x) && \separated(x, y) && *y == b_init && *x == a_init;
+  ensures b == \old(y) && a == \old(x) && \old(b_init) == b_init && \old(a_init) == a_init && \old(r) == r && \old(b) == \old(y) && \old(a) == \old(x) && \valid(y) && \valid(x) && \separated(x, y) && ((\result == b_init && b_init - a_init >= 1) || (\result == a_init && a_init >= b_init));
 */
 ================================================================================
 
@@ -77,8 +77,8 @@ Inferred ACSL annotations
 ================================================================================
 /* contract for findMax */
 /*@
-  requires b == y && a == x && r == max && \separated(y, max) && \separated(x, y) && \separated(x, max) && \valid(y) && \valid(x) && \valid(max);
-  ensures b_init == \old(b_init) && a_init == \old(a_init) && \old(max) == r && \old(y) == b && \old(x) == a && \old(b) == b && \old(a) == a && \old(r) == r && \separated(b, r) && \separated(a, b) && \separated(a, r) && \valid(b) && \valid(a) && \valid(r) && (\old(a_init) >= \old(b_init) || (\old(b_init) - \old(a_init) >= 1 && *r == \old(b_init))) && (*r == \old(a_init) || (\old(b_init) - \old(a_init) >= 1 && *r == \old(b_init)));
+  requires b == y && a == x && r == max && \valid(y) && \valid(x) && \valid(max) && \separated(y, max) && \separated(x, y) && \separated(x, max) && *y == b_init && *x == a_init;
+  ensures b_init == \old(b_init) && a_init == \old(a_init) && \old(max) == r && \old(y) == b && \old(x) == a && \old(b) == b && \old(a) == a && \old(r) == r && \valid(b) && \valid(a) && \valid(r) && \separated(b, r) && \separated(a, b) && \separated(a, r) && (\old(a_init) >= \old(b_init) || (\old(b_init) - \old(a_init) >= 1 && *r == \old(b_init))) && (*r == \old(a_init) || (\old(b_init) - \old(a_init) >= 1 && *r == \old(b_init)));
 */
 ================================================================================
 
@@ -92,13 +92,13 @@ Inferred ACSL annotations
 ================================================================================
 /* contract for addTwoNumbers */
 /*@
-  requires \separated(b, result) && \separated(a, result) && \separated(a, b) && \valid(result) && \valid(b) && \valid(a);
-  ensures \old(b_init) == b_init && \old(a_init) == a_init && \old(result) == result && \old(b) == b && \old(a) == a && \separated(b, result) && \separated(a, result) && \separated(a, b) && \valid(result) && \valid(b) && \valid(a) && \old(*b) + \old(*a) - *result == 0;
+  requires \valid(result) && \valid(b) && \valid(a) && \separated(b, result) && \separated(a, result) && \separated(a, b);
+  ensures \old(b_init) == b_init && \old(a_init) == a_init && \old(result) == result && \old(b) == b && \old(a) == a && \valid(result) && \valid(b) && \valid(a) && \separated(b, result) && \separated(a, result) && \separated(a, b) && \old(*b) + \old(*a) - *result == 0;
 */
 /* contract for multiplyByTwo */
 /*@
-  requires a == num && \separated(b, result) && \separated(num, result) && \separated(num, b) && \valid(result) && \valid(b) && \valid(num);
-  ensures \old(b_init) == b_init && \old(a_init) == a_init && \old(result) == result && \old(b) == b && \old(a) == \old(num) && a == \old(num) && \separated(b, result) && \separated(num, result) && \separated(num, b) && \valid(result) && \valid(b) && \valid(num) && 2*\old(*num) == *num;
+  requires a == num && \valid(result) && \valid(b) && \valid(num) && \separated(b, result) && \separated(num, result) && \separated(num, b) && *b == b_init && *num == a_init;
+  ensures \old(b_init) == b_init && \old(a_init) == a_init && \old(result) == result && \old(b) == b && \old(a) == \old(num) && a == \old(num) && \valid(result) && \valid(b) && \valid(num) && \separated(b, result) && \separated(num, result) && \separated(num, b) && 2*\old(*num) == *num;
 */
 ================================================================================
 
@@ -128,7 +128,7 @@ Inferred ACSL annotations
 ================================================================================
 /* contract for swap */
 /*@
-  requires \true;
+  requires \valid(y) && \valid(x);
   ensures \valid(y) && \valid(x) && *x == \old(*y) && \old(*x) == *y;
 */
 ================================================================================
@@ -146,8 +146,8 @@ Inferred ACSL annotations
 ================================================================================
 /* contract for mod */
 /*@
-  requires \separated(t1, t2) && \valid(t2) && \valid(t1);
-  ensures \separated(t1, t2) && \valid(t2) && \valid(t1) && \old(*t1) - *t1 == -1 && \old(*t2) - *t2 == 1;
+  requires \valid(t1) && \valid(t2) && \separated(t1, t2) && *t2 == 2;
+  ensures \valid(t2) && \valid(t1) && \separated(t1, t2) && \old(*t1) - *t1 == -1 && \old(*t2) - *t2 == 1;
 */
 ================================================================================
 
@@ -159,8 +159,8 @@ Inferred ACSL annotations
 ================================================================================
 /* contract for mod */
 /*@
-  requires \separated(t3, t4) && \separated(t2, t4) && \separated(t2, t3) && \separated(t1, t4) && \separated(t1, t3) && \separated(t1, t2) && \valid(t4) && \valid(t3) && \valid(t2) && \valid(t1);
-  ensures \separated(t3, t4) && \separated(t2, t4) && \separated(t2, t3) && \separated(t1, t4) && \separated(t1, t3) && \separated(t1, t2) && \valid(t4) && \valid(t3) && \valid(t2) && \valid(t1) && 2*\old(*t3) == *t3 && \old(*t2) - *t2 == 1 && *t1 - \old(*t1) == 2 && 2*\old(*t1) - *t4 == -4;
+  requires \valid(t4) && \valid(t3) && \valid(t2) && \valid(t1) && \separated(t3, t4) && \separated(t2, t4) && \separated(t2, t3) && \separated(t1, t4) && \separated(t1, t3) && \separated(t1, t2);
+  ensures \valid(t4) && \valid(t3) && \valid(t2) && \valid(t1) && \separated(t3, t4) && \separated(t2, t4) && \separated(t2, t3) && \separated(t1, t4) && \separated(t1, t3) && \separated(t1, t2) && 2*\old(*t3) == *t3 && \old(*t2) - *t2 == 1 && *t1 - \old(*t1) == 2 && 2*\old(*t1) - *t4 == -4;
 */
 ================================================================================
 
@@ -174,6 +174,19 @@ Inferred ACSL annotations
 /*@
   requires \valid(s) && s->x >= 0;
   ensures \valid(s) && s->x - \result == -1;
+*/
+================================================================================
+
+SAFE
+
+enum-indexed-struct.c
+
+Inferred ACSL annotations
+================================================================================
+/* contract for helper_read_record */
+/*@
+  requires slot == 1;
+  ensures \old(slot) == 1 && \old(records) == records;
 */
 ================================================================================
 

--- a/regression-tests/toh-contract-translation/Answers
+++ b/regression-tests/toh-contract-translation/Answers
@@ -191,3 +191,16 @@ Inferred ACSL annotations
 ================================================================================
 
 SAFE
+
+enum-indexed-struct-field.c
+
+Inferred ACSL annotations
+================================================================================
+/* contract for helper_read_level */
+/*@
+  requires slot == 1;
+  ensures \old(slot) == 1 && \old(records) == records && records[1].level == \result;
+*/
+================================================================================
+
+SAFE

--- a/regression-tests/toh-contract-translation/Answers
+++ b/regression-tests/toh-contract-translation/Answers
@@ -186,7 +186,7 @@ Inferred ACSL annotations
 /* contract for helper_read_record */
 /*@
   requires slot == 1;
-  ensures \old(slot) == 1 && \old(records) == records;
+  ensures \old(slot) == 1 && \old(records) == records && records[1] == \result;
 */
 ================================================================================
 

--- a/regression-tests/toh-contract-translation/enum-indexed-struct-field.c
+++ b/regression-tests/toh-contract-translation/enum-indexed-struct-field.c
@@ -1,0 +1,26 @@
+enum RecordSlot {
+    RECORD_LOW = 0,
+    RECORD_HIGH = 1
+};
+
+struct SlotRecord {
+    int level;
+    int status;
+};
+
+struct SlotRecord records[2] = {
+    {3, 0},
+    {8, 1}
+};
+
+/*@contract@*/
+int helper_read_level(enum RecordSlot slot)
+{
+    return records[slot].level;
+}
+
+int entry(void)
+{
+    int level = helper_read_level(RECORD_HIGH);
+    assert(level == 8);
+}

--- a/regression-tests/toh-contract-translation/enum-indexed-struct.c
+++ b/regression-tests/toh-contract-translation/enum-indexed-struct.c
@@ -1,0 +1,26 @@
+enum RecordSlot {
+    RECORD_LOW = 0,
+    RECORD_HIGH = 1
+};
+
+struct SlotRecord {
+    int level;
+    int status;
+};
+
+struct SlotRecord records[2] = {
+    {3, 0},
+    {8, 1}
+};
+
+/*@contract@*/
+struct SlotRecord helper_read_record(enum RecordSlot slot)
+{
+    return records[slot];
+}
+
+int entry(void)
+{
+    struct SlotRecord selected = helper_read_record(RECORD_HIGH);
+    assert(selected.level == 8);
+}

--- a/regression-tests/toh-contract-translation/runtests
+++ b/regression-tests/toh-contract-translation/runtests
@@ -17,7 +17,7 @@ for name in $TESTS; do
     $TRI_CMD -cex -acsl "$@" $name 2>&1 | grep -v 'at '
 done
 
-TESTS="struct-field-read.c"
+TESTS="struct-field-read.c enum-indexed-struct.c"
 for name in $TESTS; do
     echo
     echo $name

--- a/regression-tests/toh-contract-translation/runtests
+++ b/regression-tests/toh-contract-translation/runtests
@@ -17,7 +17,7 @@ for name in $TESTS; do
     $TRI_CMD -cex -acsl "$@" $name 2>&1 | grep -v 'at '
 done
 
-TESTS="struct-field-read.c enum-indexed-struct.c"
+TESTS="struct-field-read.c enum-indexed-struct.c enum-indexed-struct-field.c"
 for name in $TESTS; do
     echo
     echo $name

--- a/src/main/scala/tricera/HeapInfo.scala
+++ b/src/main/scala/tricera/HeapInfo.scala
@@ -1,5 +1,6 @@
 /**
- * Copyright (c) 2025 Scania CV AB. All rights reserved.
+ * Copyright (c) 2025 Scania CV AB
+ *               2026 Zafer Esen. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -28,12 +29,37 @@
  */
 package tricera
 
-import ap.theories.heaps.Heap
+import ap.theories.ADT
+import ap.theories.heaps.{ArrayHeap, Heap, NativeHeap}
 import ap.parser.IFunction
+import tricera.concurrency.ccreader.ArrayPtrOps
 import tricera.concurrency.heap.{HeapModel, HeapTheoryModel}
 
 
 final case class HeapInfo(heap: Heap, heapModel : HeapModel) {
+  private val arrayPtrOps : Option[ArrayPtrOps] = heapModel match {
+    case m : HeapTheoryModel => Some(m.arrayPtrOps)
+    case _ => None
+  }
+
+  private val rangeStartSel : Option[IFunction] =
+    ADT.Selector.unapply(heap.rangeSize).map {
+      case (adt, ctorIndex, _) => adt.selectors(ctorIndex)(0)
+    }
+
+  def isRangeNth(function : IFunction) : Boolean = function == heap.rangeNth
+
+  def isRangeSize(function : IFunction) : Boolean = function == heap.rangeSize
+
+  def isRangeStart(function : IFunction) : Boolean =
+    rangeStartSel.contains(function)
+
+  def isArrayPtrRange(function : IFunction) : Boolean =
+    arrayPtrOps.exists(_.rangeSel == function)
+
+  def isArrayPtrOffset(function : IFunction) : Boolean =
+    arrayPtrOps.exists(_.offsetSel == function)
+
   private def findObjectCtorsAndSels(heap: Heap): Map[IFunction, Option[IFunction]] = {
     heap.userHeapConstructors
       .zip(heap.userHeapSelectors)
@@ -70,6 +96,28 @@ final case class HeapInfo(heap: Heap, heapModel : HeapModel) {
 
   def isNewAddrFun(function: IFunction): Boolean =
     function == heap.heapAddrPair_2
+
+  def isAddrFun(function: IFunction): Boolean =
+    function == heap.addr
+
+  private def isHeapTheoryFun(function: IFunction): Boolean =
+    Heap.HeapRelatedFunction.unapply(function).contains(heap)
+
+  // The fused allocation functions are private in the heap theories, so
+  // they cannot be compared against directly.
+  def isAllocHeapFun(function: IFunction): Boolean =
+    isHeapTheoryFun(function) &&
+      function.arity == 2 && function.name == "allocHeap"
+
+  def isAllocAddrFun(function: IFunction): Boolean =
+    isHeapTheoryFun(function) &&
+      function.arity == 2 && function.name == "allocAddr"
+
+  val heapSizeFun: Option[IFunction] = heap match {
+    case h: NativeHeap => Some(h.heapSize)
+    case h: ArrayHeap  => Some(h.heapSize)
+    case _             => None
+  }
 
   def isHeap(constant: ProgVarProxy): Boolean = heapModel match {
     case m : HeapTheoryModel =>

--- a/src/main/scala/tricera/Main.scala
+++ b/src/main/scala/tricera/Main.scala
@@ -568,6 +568,7 @@ class Main (args: Array[String]) {
           result
             .through(FunctionInvariantsFilter(i => !i.isSrcAnnotated)(_))
             .through(ADTExploder.apply)
+            .through(HeapFactsProcessor.apply)
             .through(PostconditionSimplifier.apply)
             .through(r =>
               if (solution.isHeapUsed) { r

--- a/src/main/scala/tricera/concurrency/CCReader.scala
+++ b/src/main/scala/tricera/concurrency/CCReader.scala
@@ -1364,7 +1364,16 @@ assert(ctorObjSorts.toSet.size == ctorObjSorts.size)
                     (ArrayLocation.Stack, Some(a.constant_expression_))
                   case _ => (ArrayLocation.Heap, None)
                 }
-                (heapModelFactory.makeArrayPointer(typeWithPtrs, arrayLocation), initArrayExpr)
+                val declaredSize = arrayLocation match {
+                  case ArrayLocation.Global =>
+                    initArrayExpr.flatMap(e =>
+                      try Some(translateConstantExpr(e))
+                      catch { case _ : TranslationException => None })
+                      .map(_.toTerm).collect { case IIntLit(v) => v.intValueSafe }
+                  case _ => None
+                }
+                (heapModelFactory.makeArrayPointer(typeWithPtrs, arrayLocation)
+                   .copy(declaredSize = declaredSize), initArrayExpr)
               }
               // todo: adjust needsHeap below if an array type does not require heap
               // for instance if we model arrays using the theory of arrays or unroll

--- a/src/main/scala/tricera/concurrency/CCReader.scala
+++ b/src/main/scala/tricera/concurrency/CCReader.scala
@@ -1381,7 +1381,13 @@ assert(ctorObjSorts.toSet.size == ctorObjSorts.size)
                     (ArrayLocation.Stack, Some(a.constant_expression_))
                   case _ => (ArrayLocation.Heap, None)
                 }
-                (CCArray(typeWithPtrs, None, None, ExtArray(scala.Seq(CCInt.toSort), typeWithPtrs.toSort), arrayLocation), initArrayExpr)
+                val sizeTerm = initArrayExpr.flatMap(e =>
+                  try Some(translateConstantExpr(e))
+                  catch { case _ : Throwable => None })
+                val sizeInt = sizeTerm.map(_.toTerm).collect {
+                  case IIntLit(v) => v.intValueSafe
+                }
+                (CCArray(typeWithPtrs, sizeTerm, sizeInt, ExtArray(scala.Seq(CCInt.toSort), typeWithPtrs.toSort), arrayLocation), initArrayExpr)
               }
               // todo: adjust needsHeap below if an array type does not require heap
               // for instance if we model arrays using the theory of arrays or unroll

--- a/src/main/scala/tricera/concurrency/ccreader/CCType.scala
+++ b/src/main/scala/tricera/concurrency/ccreader/CCType.scala
@@ -635,7 +635,8 @@ case class CCHeapArrayPointer(addressRangeSort: Sort,
                               zeroInitAddrRange: ITerm,
                               elementType:       CCType,
                               arrayLocation:     ArrayLocation,
-                              ptrOps:            ArrayPtrOps)
+                              ptrOps:            ArrayPtrOps,
+                              declaredSize:      Option[Int] = None)
     extends CCType {
   def shortName = "[]"
 }

--- a/src/main/scala/tricera/concurrency/ccreader/CCType.scala
+++ b/src/main/scala/tricera/concurrency/ccreader/CCType.scala
@@ -287,7 +287,8 @@ abstract sealed class CCType {
       structType.ctor(const: _*)
     case p : CCHeapPointer                => p.nullAddr
     case p : CCHeapArrayPointer           => p.zeroInitAddrRange
-    case CCArray(_, _, _, arrayTheory, _) => arrayTheory.const(0)
+    case CCArray(elementType, _, _, arrayTheory, _) =>
+      arrayTheory.const(elementType.getZeroInit)
     case _                                => IIntLit(0)
   }
 }

--- a/src/main/scala/tricera/postprocessor/ACSLExpressionProcessor.scala
+++ b/src/main/scala/tricera/postprocessor/ACSLExpressionProcessor.scala
@@ -1,6 +1,7 @@
 /**
- * Copyright (c) 2023 Oskar Soederberg. All rights reserved.
- * 
+ * Copyright (c) 2023 Oskar Soederberg
+ *               2026 Zafer Esen. All rights reserved.
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  * 
@@ -109,6 +110,44 @@ object ACSLExpressionProcessor extends ResultProcessor {
     }
 
     private def isOldHeap(p: ProgVarProxy): Boolean = heapInfo.isHeap(p) && p.isPreExec
+
+    private object ArrayPtrRange {
+      def unapply(t: ITerm): Option[ProgVarProxy] = t match {
+        case IFunApp(rangeSel, Seq(ConstantAsProgVarProxy(array)))
+            if heapInfo.isArrayPtrRange(rangeSel) => Some(array)
+        case _ => None
+      }
+    }
+
+    // rangeNth(rangeSel(a), i) or rangeStart(rangeSel(a)) + i
+    private object ArrayElementAddress {
+      def unapply(address: ITerm): Option[(ProgVarProxy, ITerm)] = address match {
+        case IFunApp(nth, Seq(ArrayPtrRange(array), index))
+            if heapInfo.isRangeNth(nth) && isCleanIndex(index) =>
+          Some((array, index))
+        case IPlus(index, IFunApp(start, Seq(ArrayPtrRange(array))))
+            if heapInfo.isRangeStart(start) && isCleanIndex(index) =>
+          Some((array, index))
+        case IPlus(IFunApp(start, Seq(ArrayPtrRange(array))), index)
+            if heapInfo.isRangeStart(start) && isCleanIndex(index) =>
+          Some((array, index))
+        case _ => None
+      }
+    }
+
+    private def isCleanIndex(index: ITerm): Boolean =
+      !ContainsTOHVisitor(index, heapInfo)
+
+    // Bare constants inside an ACSL index denote entry-state values in a
+    // precondition and, wrapped in \old, pre-state values in a postcondition;
+    // otherwise they denote post-state values. Parameters always denote their
+    // entry values in ACSL contracts.
+    private def indexStateOk(index: ITerm, oldState: Boolean): Boolean =
+      SymbolCollector.constants(index).forall {
+        case p: ProgVarProxy =>
+          p.isParameter || (if (oldState) p.isPreExec else !p.isPreExec)
+        case _ => false
+      }
 
     override def postVisit(
         t: IExpression,
@@ -244,6 +283,47 @@ object ACSLExpressionProcessor extends ResultProcessor {
             // SSSOWO TODO: What about loop invariants?
             case _ => t update subres
           }
+        }
+
+        // read(h, element address of a[i]).get_<sort> ~> a[i]
+        case IFunApp(getFun, Seq(
+          TheoryOfHeapFunApp(readFun,
+            Seq(ConstantAsProgVarProxy(h), ArrayElementAddress(array, index))
+          ))) if heapInfo.isObjSelector(getFun) &&
+          heapInfo.isReadFun(readFun) &&
+          heapInfo.isHeap(h) => context match {
+          case _: PreCondition =>
+            ACSLExpression.arrayAccessFunApp(
+              ACSLExpression.arrayAccess, array, index)
+          case _: PostCondition =>
+            (
+              isOldHeap(h),
+              array.isPreExec,
+              array.isParameter
+            ) match {
+              case (false, false, false)
+                if indexStateOk(index, oldState = false) =>
+                // read(@h, a), a not param => a[i]
+                ACSLExpression.arrayAccessFunApp(
+                  ACSLExpression.arrayAccess, array, index)
+              case (false, true, true)
+                if indexStateOk(index, oldState = false) =>
+                // read(@h, a_0), a is param => a[i]
+                ACSLExpression.arrayAccessFunApp(
+                  ACSLExpression.arrayAccess, array, index)
+              case (false, true, false)
+                if indexStateOk(index, oldState = false) =>
+                // read(@h, a_0), a not param => \old(a)[i]
+                ACSLExpression.arrayAccessFunApp(
+                  ACSLExpression.arrayAccessOldPointer, array, index)
+              case (true, true, _)
+                if indexStateOk(index, oldState = true) =>
+                // read(@h_0, a_0) => \old(a[i])
+                ACSLExpression.arrayAccessFunApp(
+                  ACSLExpression.oldArrayAccess, array, index)
+              case _ => t update subres
+            }
+          case _ => t update subres
         }
         case _ => t update subres
       }

--- a/src/main/scala/tricera/postprocessor/ACSLExpressionProcessor.scala
+++ b/src/main/scala/tricera/postprocessor/ACSLExpressionProcessor.scala
@@ -285,6 +285,56 @@ object ACSLExpressionProcessor extends ResultProcessor {
           }
         }
 
+        // field(read(h, element address of a[i]).get_<sort>) ~> a[i].f
+        case IFunApp(selector: MonoSortedIFunction, Seq(
+          IFunApp(getFun, Seq(
+            TheoryOfHeapFunApp(readFun,
+              Seq(ConstantAsProgVarProxy(h), ArrayElementAddress(array, index))
+            ))))) if heapInfo.isObjSelector(getFun) &&
+          heapInfo.isReadFun(readFun) &&
+          isSelector(selector) &&
+          heapInfo.isHeap(h) => context match {
+          case _: PreCondition =>
+            ACSLExpression.arrayFieldAccessFunApp(
+              ACSLExpression.arrayFieldAccess,
+              ACSLExpression.arrayAccessFunApp(
+                ACSLExpression.arrayAccess, array, index),
+              selector)
+          case _: PostCondition =>
+            (
+              isOldHeap(h),
+              array.isPreExec,
+              array.isParameter
+            ) match {
+              case (false, false, false) | (false, true, true)
+                if indexStateOk(index, oldState = false) =>
+                // read(@h, a) => a[i].f
+                ACSLExpression.arrayFieldAccessFunApp(
+                  ACSLExpression.arrayFieldAccess,
+                  ACSLExpression.arrayAccessFunApp(
+                    ACSLExpression.arrayAccess, array, index),
+                  selector)
+              case (false, true, false)
+                if indexStateOk(index, oldState = false) =>
+                // read(@h, a_0), a not param => \old(a)[i].f
+                ACSLExpression.arrayFieldAccessFunApp(
+                  ACSLExpression.arrayFieldAccess,
+                  ACSLExpression.arrayAccessFunApp(
+                    ACSLExpression.arrayAccessOldPointer, array, index),
+                  selector)
+              case (true, true, _)
+                if indexStateOk(index, oldState = true) =>
+                // read(@h_0, a_0) => \old(a[i].f)
+                ACSLExpression.arrayFieldAccessFunApp(
+                  ACSLExpression.oldArrayFieldAccess,
+                  ACSLExpression.arrayAccessFunApp(
+                    ACSLExpression.arrayAccess, array, index),
+                  selector)
+              case _ => t update subres
+            }
+          case _ => t update subres
+        }
+
         // read(h, element address of a[i]).get_<sort> ~> a[i]
         case IFunApp(getFun, Seq(
           TheoryOfHeapFunApp(readFun,

--- a/src/main/scala/tricera/postprocessor/ACSLFunctions.scala
+++ b/src/main/scala/tricera/postprocessor/ACSLFunctions.scala
@@ -51,9 +51,16 @@ object ACSLExpression {
   val arrowOldPointer =
     new IFunction("arrowOldPointer", 2, false, false) // \old(p)->a
   val oldArrow = new IFunction("oldArrow", 2, false, false) // \old(p->a)
+  val arrayAccess = new IFunction("arrayAccess", 2, false, false) // a[i]
+  val arrayAccessOldPointer =
+    new IFunction("arrayAccessOldPointer", 2, false, false) // \old(a)[i]
+  val oldArrayAccess =
+    new IFunction("oldArrayAccess", 2, false, false) // \old(a[i])
   val separated = new Predicate("\\separated", 2) // \separated(p1, p2)
 
-  val functions = Set(deref, oldDeref, derefOldPointer, arrow, arrowOldPointer, oldArrow)
+  val functions = Set(deref, oldDeref, derefOldPointer, arrow, arrowOldPointer,
+                      oldArrow, arrayAccess, arrayAccessOldPointer,
+                      oldArrayAccess)
   val predicates = Set(valid, separated)
 
   def fun2Identifier(fun : IFunction) = fun.name.split("::").last
@@ -63,6 +70,14 @@ object ACSLExpression {
       pointer: ProgVarProxy
   ) = {
     IFunApp(derefFunction, Seq(IConstant(pointer)))
+  }
+
+  def arrayAccessFunApp(
+      arrayFunction: IFunction,
+      array: ProgVarProxy,
+      index: ITerm
+  ): IFunApp = {
+    IFunApp(arrayFunction, Seq(IConstant(array), index))
   }
 
   def arrowFunApp(

--- a/src/main/scala/tricera/postprocessor/ACSLFunctions.scala
+++ b/src/main/scala/tricera/postprocessor/ACSLFunctions.scala
@@ -1,6 +1,6 @@
 /**
  * Copyright (c) 2023 Oskar Soederberg
- *               2025 Zafer Esen. All rights reserved.
+ *               2025-2026 Zafer Esen. All rights reserved.
  * 
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -115,6 +115,9 @@ def separatedPointers(pointerEquivs : ValSet) : IFormula = {
       case _ => IBoolLit(true)
     }
   }
+
+  val functionsSorted  : Seq[IFunction] = functions.toSeq.sortBy(_.name)
+  val predicatesSorted : Seq[Predicate] = predicates.toSeq.sortBy(_.name)
 }
 
 object ACSLFunction {

--- a/src/main/scala/tricera/postprocessor/ACSLFunctions.scala
+++ b/src/main/scala/tricera/postprocessor/ACSLFunctions.scala
@@ -56,11 +56,15 @@ object ACSLExpression {
     new IFunction("arrayAccessOldPointer", 2, false, false) // \old(a)[i]
   val oldArrayAccess =
     new IFunction("oldArrayAccess", 2, false, false) // \old(a[i])
+  val arrayFieldAccess =
+    new IFunction("arrayFieldAccess", 2, false, false) // a[i].f, \old(a)[i].f
+  val oldArrayFieldAccess =
+    new IFunction("oldArrayFieldAccess", 2, false, false) // \old(a[i].f)
   val separated = new Predicate("\\separated", 2) // \separated(p1, p2)
 
   val functions = Set(deref, oldDeref, derefOldPointer, arrow, arrowOldPointer,
                       oldArrow, arrayAccess, arrayAccessOldPointer,
-                      oldArrayAccess)
+                      oldArrayAccess, arrayFieldAccess, oldArrayFieldAccess)
   val predicates = Set(valid, separated)
 
   def fun2Identifier(fun : IFunction) = fun.name.split("::").last
@@ -78,6 +82,17 @@ object ACSLExpression {
       index: ITerm
   ): IFunApp = {
     IFunApp(arrayFunction, Seq(IConstant(array), index))
+  }
+
+  def arrayFieldAccessFunApp(
+      fieldFunction: IFunction,
+      arrayApp: IFunApp,
+      selector: MonoSortedIFunction
+  ): IFunApp = {
+    IFunApp(
+      fieldFunction,
+      Seq(arrayApp, IConstant(new ConstantTerm(fun2Identifier(selector))))
+    )
   }
 
   def arrowFunApp(

--- a/src/main/scala/tricera/postprocessor/ACSLLineariser.scala
+++ b/src/main/scala/tricera/postprocessor/ACSLLineariser.scala
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020-2022 Zafer Esen, Philipp Ruemmer. All rights reserved.
+ * Copyright (c) 2020-2026 Zafer Esen, Philipp Ruemmer. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -433,6 +433,13 @@ object ACSLLineariser {
         case IFunApp(ACSLExpression.oldArrayAccess, Seq(_, _)) =>
           print("\\old(")
           allButLast(ctxt setPrecLevel 0, "[", "])", 2)
+
+        case IFunApp(ACSLExpression.arrayFieldAccess, Seq(_, _: IConstant)) =>
+          allButLast(ctxt setPrecLevel 0, ".", "", 2)
+
+        case IFunApp(ACSLExpression.oldArrayFieldAccess, Seq(_, _: IConstant)) =>
+          print("\\old(")
+          allButLast(ctxt setPrecLevel 0, ".", ")", 2)
            
         case IFunApp(fun, _) => {
           if (fun.arity == 1) {

--- a/src/main/scala/tricera/postprocessor/ACSLLineariser.scala
+++ b/src/main/scala/tricera/postprocessor/ACSLLineariser.scala
@@ -422,6 +422,17 @@ object ACSLLineariser {
         case IFunApp(ACSLExpression.oldArrow, Seq(_: IConstant, _: IConstant)) =>
           print("\\old(")
           allButLast(ctxt setPrecLevel 0, "->", ")", 2)
+
+        case IFunApp(ACSLExpression.arrayAccess, Seq(_, _)) =>
+          allButLast(ctxt setPrecLevel 0, "[", "]", 2)
+
+        case IFunApp(ACSLExpression.arrayAccessOldPointer, Seq(_, _)) =>
+          print("\\old(")
+          allButLast(ctxt setPrecLevel 0, ")[", "]", 2)
+
+        case IFunApp(ACSLExpression.oldArrayAccess, Seq(_, _)) =>
+          print("\\old(")
+          allButLast(ctxt setPrecLevel 0, "[", "])", 2)
            
         case IFunApp(fun, _) => {
           if (fun.arity == 1) {

--- a/src/main/scala/tricera/postprocessor/ClauseRemover.scala
+++ b/src/main/scala/tricera/postprocessor/ClauseRemover.scala
@@ -196,6 +196,11 @@ object ContainsTOHVisitor {
       case IFunApp(fun, _)
         if heapInfo.isObjSelector(fun) || heapInfo.isObjCtor(fun) =>
         ShortCutResult(true)
+      case IFunApp(fun, _)
+        if heapInfo.isArrayPtrRange(fun) || heapInfo.isArrayPtrOffset(fun) ||
+          heapInfo.isRangeNth(fun) || heapInfo.isRangeStart(fun) ||
+          heapInfo.isRangeSize(fun) =>
+        ShortCutResult(true)
       case Is_O_Sort(_) =>
         ShortCutResult(true)
       case _ =>

--- a/src/main/scala/tricera/postprocessor/ClauseRemover.scala
+++ b/src/main/scala/tricera/postprocessor/ClauseRemover.scala
@@ -1,6 +1,7 @@
 /**
  * Copyright (c) 2023 Oskar Soederberg
- *               2025 Scania CV AB. All rights reserved.
+ *               2025 Scania CV AB.
+                 2026 Zafer Esen All rights reserved.
  * 
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -138,13 +139,9 @@ object TheoryOfHeapRemoverVisitor {
           case (IBoolLit(true), IBoolLit(true)) =>
             // Both sides were removed during traversal
             IBoolLit(true)
-          case (IBoolLit(true), _) =>
-            // LHS has been removed
-            rhs
-          case (_, IBoolLit(true)) =>
-            // RHS has been removed
-            lhs
-          case _ => 
+          case (IBoolLit(true), _) | (_, IBoolLit(true)) =>
+            IBoolLit(true)
+          case _ =>
             // Neither side was removed during traversal
             form update subres
         }
@@ -230,6 +227,9 @@ object ExplicitPointerRemover {
         subres: Seq[IExpression]
     ): IExpression = {
       t update subres match {
+      case INot(IBoolLit(true)) =>
+        // the negated subformula was removed, not proved true
+        IBoolLit(true)
       case f: IFormula if ContainsExplicitPointerVisitor(f) =>
         IBoolLit(true)
       case _ =>

--- a/src/main/scala/tricera/postprocessor/EqualitySwapper.scala
+++ b/src/main/scala/tricera/postprocessor/EqualitySwapper.scala
@@ -76,7 +76,8 @@ object ToVariableForm extends ResultProcessor {
       Invariant(
         EqualitySwapper(
           form,
-          valueSet.toCanonicalFormMap).asInstanceOf[IFormula],
+          valueSet.toCanonicalFormMap,
+          maybeHeapInfo).asInstanceOf[IFormula],
         maybeHeapInfo,
         maybeSourceInfo)
   }
@@ -88,12 +89,14 @@ object ToExplicitForm {
 }
 
 object EqualitySwapper {
-  def apply(expr : IExpression, swapMap : Map[IExpression, ITerm]) =
-    (new EqualitySwapper(swapMap))(expr)
+  def apply(expr : IExpression, swapMap : Map[IExpression, ITerm],
+            heapInfo : Option[HeapInfo] = None) =
+    (new EqualitySwapper(swapMap, heapInfo))(expr)
 }
 
-class EqualitySwapper(swapMap : Map[IExpression, ITerm])
-    extends CollectingVisitor[Int, IExpression] 
+class EqualitySwapper(swapMap : Map[IExpression, ITerm],
+                      heapInfo : Option[HeapInfo] = None)
+    extends CollectingVisitor[Int, IExpression]
     with ExpressionUtils {
   def apply(contractCondition : IExpression) : IExpression = {
     def rewriter(expr : IExpression) : IExpression = {
@@ -114,6 +117,9 @@ class EqualitySwapper(swapMap : Map[IExpression, ITerm])
     val updated = t update subres
     (updated, swapMap.getOrElse(updated, updated)) match {
       case (IFunApp(_, Seq()), swapped: IConstant) =>
+        swapped
+      case (IFunApp(fun, _), swapped: IConstant)
+          if heapInfo.exists(_.isAddrFun(fun)) =>
         swapped
       case _ =>
         updated

--- a/src/main/scala/tricera/postprocessor/FormulaSimplifier.scala
+++ b/src/main/scala/tricera/postprocessor/FormulaSimplifier.scala
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2025 Zafer Esen. All rights reserved.
+ * Copyright (c) 2025-2026 Zafer Esen. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -73,8 +73,8 @@ class FormulaSimplifier extends SolutionProcessor {
       val theoryCollector = new TheoryCollector
       theoryCollector(expr)
       p.addTheories(theoryCollector.theories)
-      ACSLExpression.functions.foreach(f => p.addFunction(f))
-      ACSLExpression.predicates.foreach(r => p.addRelation(r))
+      ACSLExpression.functionsSorted.foreach(f => p.addFunction(f))
+      ACSLExpression.predicatesSorted.foreach(r => p.addRelation(r))
       p.simplify(expr)
     }
 }

--- a/src/main/scala/tricera/postprocessor/HeapFactsProcessor.scala
+++ b/src/main/scala/tricera/postprocessor/HeapFactsProcessor.scala
@@ -1,0 +1,204 @@
+/**
+ * Copyright (c) 2026 Zafer Esen. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the authors nor the names of their
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package tricera.postprocessor
+
+import ap.parser._
+import ap.terfor.conjunctions.Quantifier
+import IExpression.{Conj, Eq, i}
+import tricera._
+
+import scala.collection.mutable
+import scala.collection.mutable.ArrayBuffer
+
+/**
+ * Adds heap facts to preconditions to be used in later stages.
+ * Heap facts are extracted from alloc/write chains, addresses, heap sizes etc.
+ */
+object HeapFactsProcessor extends ResultProcessor {
+  override def applyTo(solution : Solution) : Solution = solution match {
+    case Solution(functionInvariants, loopInvariants) =>
+      Solution(functionInvariants.map(applyTo), loopInvariants)
+  }
+
+  private def applyTo(funcInvs : FunctionInvariants) : FunctionInvariants =
+    funcInvs.preCondition.invariant match {
+      case Invariant(form, Some(heapInfo), srcInfo) =>
+        val facts = ChainFactsReader(form, heapInfo)
+        if (facts.isEmpty) funcInvs
+        else {
+          val newInvs = funcInvs.copy(preCondition = PreCondition(Invariant(
+            facts.foldLeft(form)(_ & _), Some(heapInfo), srcInfo)))
+          DebugPrinter.oldAndNew(this, funcInvs, newInvs)
+          newInvs
+        }
+      case _ => funcInvs
+    }
+}
+
+private object ChainFactsReader {
+  def apply(form : IFormula, heapInfo : HeapInfo) : Seq[IFormula] =
+    (new ChainFactsReader(heapInfo)).factsOf(form)
+}
+
+private class ChainFactsReader(heapInfo : HeapInfo) {
+  private val addrNumberOfTerm = new mutable.LinkedHashMap[ITerm, Int]
+  private val heapChains = new ArrayBuffer[(ITerm, Int, Seq[(ITerm, ITerm)])]
+
+  def factsOf(form : IFormula) : Seq[IFormula] = {
+    collect(form)
+
+    val addrFacts =
+      for ((term, addrNumber) <- addrNumberOfTerm.toSeq)
+        yield Eq(term, addrTerm(addrNumber))
+
+    val chainFacts = heapChains.flatMap { case (heapVar, allocCount, writes) =>
+      //size only depends on the alloc count, can always be added
+      val sizeFact = heapInfo.heapSizeFun.map(
+        sizeFun => Eq(IFunApp(sizeFun, Seq(heapVar)), i(allocCount))).toSeq
+      sizeFact ++ readFacts(heapVar, writes)
+    }
+
+    addrFacts ++ chainFacts
+  }
+
+  // only sound if every written address is known (otherwise may alias)
+  private def readFacts(heapVar : ITerm,
+                        writes  : Seq[(ITerm, ITerm)]) : Seq[IFormula] = {
+    val resolved = writes.map {
+      case (addr, obj) => (resolveAddrNumber(addr), addr, obj) }
+    if (!resolved.forall(_._1.isDefined)) return Seq()
+
+    val lastWrites = new mutable.LinkedHashMap[Int, (ITerm, ITerm)]
+    for ((Some(addrNumber), addr, obj) <- resolved)
+      lastWrites(addrNumber) = (addr, obj)
+
+    for ((_, (addr, obj)) <- lastWrites.toSeq;
+         if !HasVariable(addr) && !HasVariable(obj))
+    yield Eq(IFunApp(heapInfo.heap.read, Seq(heapVar, addr)), obj)
+  }
+
+  // only positive conjuncts imply anything (not disj or neg)
+  // collecting under EX is also fine, the facts never mention bound variables
+  private def collect(f: IFormula): Unit = f match {
+    case Conj(f1, f2) =>
+      collect(f1); collect(f2)
+    case IQuantified(Quantifier.EX, sub) =>
+      collect(sub)
+    case Eq(lhs, rhs) =>
+      collectAddrEquality(lhs, rhs); collectAddrEquality(rhs, lhs)
+      collectHeapChain(lhs, rhs); collectHeapChain(rhs, lhs)
+    case _ => ()
+  }
+
+  // collects term = <address of the k-th allocation>
+  private def collectAddrEquality(term          : ITerm,
+                                  allocAddrTerm : ITerm) : Unit =
+    allocatedAddrNumber(allocAddrTerm) match {
+      case Some(k) if !HasVariable(term) &&
+                      resolveAddrNumber(term).isEmpty =>
+        addrNumberOfTerm(term) = k
+      case _ => ()
+    }
+
+  // collects <pre-state heap variable> = <alloc/write chain>
+  private def collectHeapChain(heapVar   : ITerm,
+                               chainTerm : ITerm) : Unit =
+    heapVar match {
+      case IConstant(p: ProgVarProxy)
+          if heapInfo.isHeap(p) && p.isPreExec =>
+        for ((allocCount, writes) <- chain(chainTerm))
+          heapChains += ((heapVar, allocCount, writes))
+      case _ => ()
+    }
+
+  // the k-th alloc from the empty heap yields address k
+  private def chain(term : ITerm) : Option[(Int, Seq[(ITerm, ITerm)])] =
+    term match {
+      case IFunApp(f, Seq()) if heapInfo.isEmptyHeapFun(f) =>
+        Some((0, Vector()))
+      case Allocation(heapBefore, obj) =>
+        chain(heapBefore).map { case (allocCount, writes) =>
+          (allocCount + 1, writes :+ (addrTerm(allocCount + 1), obj)) }
+      case IFunApp(f, Seq(heapBefore: ITerm, addr: ITerm, obj: ITerm))
+          if heapInfo.isWriteFun(f) =>
+        chain(heapBefore).map { case (allocCount, writes) =>
+          (allocCount, writes :+ (addr, obj)) }
+      case _ => None
+    }
+
+  // newHeap(alloc(h, obj)) or allocHeap(h, obj)
+  private object Allocation {
+    def unapply(term : ITerm) : Option[(ITerm, ITerm)] = term match {
+      case IFunApp(f1, Seq(IFunApp(f2, Seq(heapBefore: ITerm, obj: ITerm))))
+          if heapInfo.isNewHeapFun(f1) && heapInfo.isAllocFun(f2) =>
+        Some((heapBefore, obj))
+      case IFunApp(f, Seq(heapBefore: ITerm, obj: ITerm))
+          if heapInfo.isAllocHeapFun(f) =>
+        Some((heapBefore, obj))
+      case _ => None
+    }
+  }
+
+  // newAddr(alloc(h, obj)) or allocAddr(h, obj)
+  private object AllocationAddr {
+    def unapply(term : ITerm) : Option[ITerm] = term match {
+      case IFunApp(f1, Seq(IFunApp(f2, Seq(heapBefore: ITerm, _))))
+          if heapInfo.isNewAddrFun(f1) && heapInfo.isAllocFun(f2) =>
+        Some(heapBefore)
+      case IFunApp(f, Seq(heapBefore: ITerm, _))
+          if heapInfo.isAllocAddrFun(f) =>
+        Some(heapBefore)
+      case _ => None
+    }
+  }
+
+  private def allocatedAddrNumber(term : ITerm) : Option[Int] = term match {
+    case AllocationAddr(heapBefore) => chain(heapBefore).map(_._1 + 1)
+    case _ => None
+  }
+
+  private def resolveAddrNumber(term : ITerm) : Option[Int] = term match {
+    case IFunApp(f, Seq(IIntLit(k))) if heapInfo.isAddrFun(f) =>
+      Some(k.intValueSafe)
+    case _ =>
+      allocatedAddrNumber(term).orElse(addrNumberOfTerm.get(term))
+  }
+
+  private def addrTerm(addrNumber : Int) : ITerm =
+    IFunApp(heapInfo.heap.addr, Seq(i(addrNumber)))
+
+  private object HasVariable extends CollectingVisitor[Unit, Boolean] {
+    def apply(t: IExpression): Boolean = visit(t, ())
+    override def postVisit(t: IExpression,
+                           arg: Unit,
+                           subres: Seq[Boolean]): Boolean =
+      t.isInstanceOf[IVariable] || subres.contains(true)
+  }
+}

--- a/src/main/scala/tricera/postprocessor/MergeTransformedFunctionsContracts.scala
+++ b/src/main/scala/tricera/postprocessor/MergeTransformedFunctionsContracts.scala
@@ -1,5 +1,6 @@
 /**
- * Copyright (c) 2025 Scania CV AB. All rights reserved.
+ * Copyright (c) 2025 Scania CV AB
+ *               2026 Zafer Esen. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -280,16 +281,31 @@ private class MergeTransformedFunctionsContracts(callSiteTransforms: CallSiteTra
               case c: ProgVarProxy => 
                 (c.asInstanceOf[ConstantTerm], ACSLExpression.derefFunApp(ACSLExpression.deref, c))})
             .toMap
+      // derefed stack pointers are valid by construction
+      val derefParams = (preDerefMap.keySet ++ postDerefMap.keySet).collect {
+        case p: ProgVarProxy if p.isPreExec => p
+      }.toSeq.distinctBy(_.name).sortBy(p => funcParamsIds.indexOf(p.name))
       FunctionInvariants(
         id,
         isSrcAnnotated,
-        PreCondition(derefParameters(preCondition, preDerefMap)),
+        PreCondition(addValidParams(
+          derefParameters(preCondition, preDerefMap), derefParams)),
         PostCondition(derefParameters(postCondition, postDerefMap)),
         loopInvariants)
   }
 
+  private def addValidParams(invariant: Invariant,
+                             params: Seq[ProgVarProxy]): Invariant =
+    invariant match {
+      case Invariant(form, heapInfo, sourceInfo) if params.nonEmpty =>
+        val validAtoms = params.map(p =>
+          IAtom(ACSLExpression.valid, Seq(IConstant(p))): IFormula)
+        Invariant(form.&(validAtoms.reduce(_ & _)), heapInfo, sourceInfo)
+      case _ => invariant
+    }
+
   private def derefParameters(invariant: Invariant, derefMap: Map[ConstantTerm, ITerm]): Invariant = invariant match {
-    case Invariant(form, heapInfo, sourceInfo) => 
+    case Invariant(form, heapInfo, sourceInfo) =>
       Invariant(ConstantSubstVisitor(form, derefMap), heapInfo, sourceInfo)
   }
 }

--- a/src/main/scala/tricera/postprocessor/PostconditionSimplifier.scala
+++ b/src/main/scala/tricera/postprocessor/PostconditionSimplifier.scala
@@ -1,6 +1,6 @@
 /**
  * Copyright (c) 2023 Oskar Soederberg
- *               2025 Zafer Esen. All rights reserved.
+ *               2025-2026 Zafer Esen. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -42,7 +42,7 @@
 package tricera.postprocessor
 
 import ap.parser._
-import IExpression.{Conj, Disj, and, i}
+import IExpression.{Conj, Disj, and, i, or}
 import ap.SimpleAPI.ProverStatus
 import ap.SimpleAPI.TimeoutException
 import ap.theories._
@@ -67,18 +67,48 @@ object PostconditionSimplifier extends ResultProcessor {
       val newInvs = FunctionInvariants(
         id, isSrcAnnotated, preCondition,
         PostCondition(Invariant(
-          simplify(postInv.expression, preCondition.invariant.expression),
+          simplify(postInv.expression,
+                   asOldState(preCondition.invariant.expression)),
           postInv.heapInfo, postInv.sourceInfo)),
         loopInvariants)
       DebugPrinter.oldAndNew(this, funcInvs, newInvs)
       newInvs
   }
 
+  // deref(p) in pre == oldDeref(p) in post
+  private def asOldState(precondition : IFormula) : IFormula =
+    OldStateVisitor.visit(precondition, ()).asInstanceOf[IFormula]
+
+  private object OldStateVisitor extends CollectingVisitor[Unit, IExpression] {
+    override def postVisit(t      : IExpression,
+                           arg    : Unit,
+                           subres : Seq[IExpression]) : IExpression =
+      t update subres match {
+        case IFunApp(fun, args) if fun == ACSLExpression.deref =>
+          IFunApp(ACSLExpression.oldDeref, args)
+        case updated => updated
+      }
+  }
+
+  // Drop !pre in !pre | Q in post
+  private def dropPreconditionGuard(postcondition : IFormula,
+                                    precondition  : IFormula) : IFormula = {
+    val preConjs = LineariseVisitor(precondition, IBinJunctor.And).toSet
+    val kept = LineariseVisitor(postcondition, IBinJunctor.Or).filterNot {
+      case INot(f) =>
+        LineariseVisitor(f, IBinJunctor.And).forall(preConjs.contains)
+      case _ => false
+    }
+    if (kept.isEmpty) postcondition else or(kept)
+  }
+
   private def simplify(postcondition : IFormula,
                        precondition  : IFormula) : IFormula = {
 
     val postConjs =
-      LineariseVisitor(Transform2NNF(postcondition), IBinJunctor.And)
+      LineariseVisitor(
+        Transform2NNF(dropPreconditionGuard(postcondition, precondition)),
+        IBinJunctor.And)
     // The reason we partition the conjuncts based on heap operations is that we
     // would like to preserve non-heap conjuncts even if they are implied by a
     // formula involving heap operations.
@@ -89,7 +119,8 @@ object PostconditionSimplifier extends ResultProcessor {
     // using non-heap conjuncts though.
     val (postHeapConjs, otherConjs) =
       postConjs.partition(c => HeapFunDetector(c))
-    val simpHeap  = simplifyHelper(and(postHeapConjs), precondition)
+    val simpHeap  = simplifyHelper(and(postHeapConjs),
+                                   precondition &&& and(otherConjs))
     simpHeap &&& and(otherConjs)
   }
 
@@ -123,8 +154,8 @@ object PostconditionSimplifier extends ResultProcessor {
       // check if context && !formula is UNSAT
       val combinedFormula = context &&& !formula
       addConstants(SymbolCollector constantsSorted combinedFormula)
-      addRelations(ACSLExpression.predicates)
-      ACSLExpression.functions.foreach(f => addFunction(f))
+      addRelations(ACSLExpression.predicatesSorted)
+      ACSLExpression.functionsSorted.foreach(f => addFunction(f))
 
       val theoryCollector = new TheoryCollector
       theoryCollector(combinedFormula)

--- a/src/main/scala/tricera/postprocessor/ResultConverter.scala
+++ b/src/main/scala/tricera/postprocessor/ResultConverter.scala
@@ -29,7 +29,8 @@
 
 package tricera.postprocessor
 
-import ap.parser.{IConstant, IFormula, VariableSubstVisitor}
+import ap.parser.{CollectingVisitor, IConstant, IExpression, IFormula,
+                  IFunApp, IIntLit, ITerm, Simplifier, VariableSubstVisitor}
 import lazabs.horn.preprocessor.HornPreprocessor
 import tricera._
 import tricera.concurrency.CCReader
@@ -45,19 +46,40 @@ object ResultConverter {
     import scala.collection.mutable.HashSet
     import Literals.{invPrefix, postExecSuffix, preExecSuffix, resultExecSuffix}
 
-    def replacePredVarWithFunctionParam(formula: IFormula, predVars: Seq[CCVar], funcParams: Seq[String]): IFormula = {
-      def stripSuffix(name: String) = {
-        if (name.endsWith(preExecSuffix)) {
-          name.dropRight(preExecSuffix.size)
-        } else if (name.endsWith(postExecSuffix)) {
-          name.dropRight(postExecSuffix.size)
-        } else if (name.endsWith(resultExecSuffix)) {
-          name.dropRight(resultExecSuffix.size)
-        } else {
-          name
-        }
+    def stripSuffix(name: String) = {
+      if (name.endsWith(preExecSuffix)) {
+        name.dropRight(preExecSuffix.size)
+      } else if (name.endsWith(postExecSuffix)) {
+        name.dropRight(postExecSuffix.size)
+      } else if (name.endsWith(resultExecSuffix)) {
+        name.dropRight(resultExecSuffix.size)
+      } else {
+        name
+      }
+    }
+
+    def globalArraySizes(predVars: Seq[CCVar]): Map[String, Int] =
+      (for (v <- predVars;
+            size <- v.typ match {
+              case p: CCHeapArrayPointer
+                if p.arrayLocation == ArrayLocation.Global => p.declaredSize
+              case _ => None
+            })
+       yield stripSuffix(v.name) -> size).toMap
+
+    // a declared global array pointer has 0 offset and known size
+    def resolveGlobalArrayFacts(formula: IFormula, predVars: Seq[CCVar],
+                                heapInfo: Option[HeapInfo]): IFormula =
+      heapInfo match {
+        case Some(info) =>
+          val sizes = globalArraySizes(predVars)
+          if (sizes.isEmpty) formula
+          else (new Simplifier)(
+            GlobalArrayFactsVisitor(formula, sizes, info))
+        case None => formula
       }
 
+    def replacePredVarWithFunctionParam(formula: IFormula, predVars: Seq[CCVar], funcParams: Seq[String]): IFormula = {
       def nameToState(name: String):ProgVarProxy.State = {
         if (name.endsWith(preExecSuffix)) {
           ProgVarProxy.State.PreExec
@@ -118,7 +140,11 @@ object ResultConverter {
         val (ccPred, srcInfo) = inv
         val (_, form) = solution.find(
           p => p._1.name.stripPrefix(invPrefix) == ccPred.pred.name).get
-        LoopInvariant(replacePredVarWithFunctionParam(form, ccPred.argVars, paramNames), heapInfo, srcInfo)
+        LoopInvariant(
+          resolveGlobalArrayFacts(
+            replacePredVarWithFunctionParam(form, ccPred.argVars, paramNames),
+            ccPred.argVars, heapInfo),
+          heapInfo, srcInfo)
     }
 
     def toFunctionInvariants(
@@ -134,17 +160,23 @@ object ResultConverter {
         funcId,
         annotatedFuncs(funcId),
         PreCondition(Invariant(
-          replacePredVarWithFunctionParam(
-            solution(ctx.prePred.pred),
+          resolveGlobalArrayFacts(
+            replacePredVarWithFunctionParam(
+              solution(ctx.prePred.pred),
+              ctx.prePred.argVars,
+              paramNames),
             ctx.prePred.argVars,
-            paramNames),
+            heapInfo),
           heapInfo,
           ctx.prePred.srcInfo)),
         PostCondition(Invariant(
-          replacePredVarWithFunctionParam(
-            solution(ctx.postPred.pred),
+          resolveGlobalArrayFacts(
+            replacePredVarWithFunctionParam(
+              solution(ctx.postPred.pred),
+              ctx.postPred.argVars,
+              paramNames),
             ctx.postPred.argVars,
-            paramNames),
+            heapInfo),
           heapInfo,
           ctx.postPred.srcInfo)),
         loopInvs
@@ -178,5 +210,40 @@ object ResultConverter {
       case Left(None) => Empty()
       case Right(cex) => CounterExample(cex)
     }
-  }  
+  }
+
+  private object GlobalArrayFactsVisitor {
+    def apply(formula: IFormula, sizes: Map[String, Int],
+              heapInfo: HeapInfo): IFormula =
+      new GlobalArrayFactsVisitor(sizes, heapInfo)
+        .visit(formula, ()).asInstanceOf[IFormula]
+  }
+
+  private class GlobalArrayFactsVisitor(
+    sizes: Map[String, Int],
+    heapInfo: HeapInfo
+  ) extends CollectingVisitor[Unit, IExpression] {
+
+    private def knownSize(t: ITerm): Option[Int] = t match {
+      case IConstant(p: ProgVarProxy) if p.isGlobal => sizes.get(p.name)
+      case _ => None
+    }
+
+    override def postVisit(
+        t: IExpression,
+        arg: Unit,
+        subres: Seq[IExpression]
+    ): IExpression = (t update subres) match {
+      case IFunApp(offsetSel, Seq(arr))
+          if heapInfo.isArrayPtrOffset(offsetSel) &&
+            knownSize(arr).isDefined =>
+        IIntLit(0)
+      case IFunApp(rangeSize, Seq(IFunApp(rangeSel, Seq(arr))))
+          if heapInfo.isRangeSize(rangeSize) &&
+            heapInfo.isArrayPtrRange(rangeSel) &&
+            knownSize(arr).isDefined =>
+        IIntLit(knownSize(arr).get)
+      case updated => updated
+    }
+  }
 }


### PR DESCRIPTION
- Sometimes the pre-condition was too weak. E.g.,`\requires true` when the method required valid pointers.
- Sometimes the post-condition was too strong. E.g., `\ensures false` or some disjuncts dropped. This was primarily a bug in ClauseRemover (the solution processor which throws away unsupported parts of the solution during backtranslation), which was sometimes throwing away disjuncts.
- Array accesses over heap was not translated back properly.

The PR attempts to fix these issues by removing the unsound weakening/strengthening parts, using only facts (e.g., known global array sizes, extracting more info about the heap from solutions etc) to simplify the inferred contracts. As a result the generated contract quality also improves (see Answers in changed files).

Subsumes #71.